### PR TITLE
Clarify installation steps in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,13 +289,15 @@ cd claude-pulse
 
 ```bash
 python claude_status.py --install
+
+# Or: python3 claude_status.py --install
 ```
 
 This adds the status line command to your `~/.claude/settings.json`.
 
 #### 3. Restart Claude Code
 
-Close and reopen Claude Code. The status bar appears at the bottom of your terminal.
+You may need to close and reopen Claude Code. The status bar appears at the bottom of your terminal.
 
 That's it. No virtual environments, no dependencies, no build steps.
 
@@ -305,7 +307,7 @@ Copy the pulse command file to your Claude Code commands directory:
 
 ```bash
 # Linux/Mac
-cp pulse.md ~/.claude/commands/pulse.md
+mkdir -p ~/.claude/commands && cp pulse.md ~/.claude/commands/pulse.md
 
 # Windows
 copy pulse.md %USERPROFILE%\.claude\commands\pulse.md


### PR DESCRIPTION
Updated installation instructions

* macOS doesn't come with `python` by default, but it does come with `python3`, and that worked fine for the installation
* The `cp` command should make sure `~/.claude/commands` exists (for me, it didn't)
* I didn't need to restart Claude to see Pulse