### PR TITLE
Add intermediate bar sizes, SSL error detection, and width clamping

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,12 +138,14 @@ python claude_status.py --theme ocean
 
 ### Configurable Bar Size
 
-Choose how wide the progress bars appear — small (4 chars), medium (8 chars, default), or large (12 chars):
+Choose how wide the progress bars appear — from small (4 chars) to large (12 chars), with medium (8 chars) as default:
 
 ```bash
-python claude_status.py --bar-size small    # ━━━━
-python claude_status.py --bar-size medium   # ━━━━━━━━
-python claude_status.py --bar-size large    # ━━━━━━━━━━━━
+python claude_status.py --bar-size small          # ━━━━
+python claude_status.py --bar-size small-medium   # ━━━━━━
+python claude_status.py --bar-size medium         # ━━━━━━━━
+python claude_status.py --bar-size medium-large   # ━━━━━━━━━━
+python claude_status.py --bar-size large          # ━━━━━━━━━━━━
 ```
 
 The bars automatically clamp to your terminal width so they never wrap to the next line.
@@ -386,7 +388,8 @@ Edit `config.json` directly or use the CLI flags:
 | `--hide <parts>` | Disable comma-separated parts |
 | `--animate on\|off` | Toggle rainbow animation (default: off) |
 | `--text-color <name>` | Set the text colour for labels/percentages (default: auto) |
-| `--bar-size <small\|medium\|large>` | Set progress bar width: 4, 8, or 12 chars (default: medium) |
+| `--bar-size <size>` | Set progress bar width: 4–12 chars (default: medium) |
+| `--max-width <20-100>` | Max status line width as % of terminal (default: 80) |
 | `--bar-style <name>` | Set bar character style (default: classic) |
 | `--layout <name>` | Set text layout (default: standard) |
 | `--currency <symbol>` | Set currency symbol for extra credits (default: £) |

--- a/commands/pulse.md
+++ b/commands/pulse.md
@@ -46,9 +46,13 @@ If $ARGUMENTS matches `currency <symbol>` (e.g. `currency £`, `currency €`, `
 -> Run `--currency <symbol>` directly.
 -> Confirm: "Currency set to **<symbol>**. Extra usage will display as <symbol>amount."
 
-If $ARGUMENTS matches `bar-size <size>` or `bars <size>` (where size is `small`, `medium`, or `large`):
+If $ARGUMENTS matches `bar-size <size>` or `bars <size>` (where size is `small`, `small-medium`, `medium`, `medium-large`, or `large`):
 -> Run `--bar-size <size>` directly.
 -> Confirm: "Bar size set to **<size>**. The status line will update on the next refresh."
+
+If $ARGUMENTS matches `max-width <number>` (where number is 20–100):
+-> Run `--max-width <number>` directly.
+-> Confirm: "Max width set to **<number>%** of terminal. The status line will update on the next refresh."
 
 If $ARGUMENTS matches `bar-style <name>` or `style <name>` (where name is `classic`, `block`, `shade`, `pipe`, `dot`, `square`, or `star`):
 -> Run `--bar-style <name>` directly.
@@ -169,10 +173,12 @@ multiSelect: false
 Options:
   - "Medium (Recommended)" — "8 characters — balanced default"
   - "Small" — "4 characters — compact, more room for text"
+  - "Small-Medium" — "6 characters — between compact and balanced"
+  - "Medium-Large" — "10 characters — slightly wider than default"
   - "Large" — "12 characters — wide bars, more visual detail"
 ```
 
-Apply with `--bar-size <small|medium|large>`.
+Apply with `--bar-size <small|small-medium|medium|medium-large|large>`.
 
 **Step 7:** Ask about context window:
 

--- a/pulse.md
+++ b/pulse.md
@@ -37,9 +37,13 @@ If $ARGUMENTS matches `currency <symbol>` (e.g. `currency £`, `currency €`, `
 -> Run `--currency <symbol>` directly.
 -> Confirm: "Currency set to **<symbol>**. Extra usage will display as <symbol>amount."
 
-If $ARGUMENTS matches `bar-size <size>` or `bars <size>` (where size is `small`, `medium`, or `large`):
+If $ARGUMENTS matches `bar-size <size>` or `bars <size>` (where size is `small`, `small-medium`, `medium`, `medium-large`, or `large`):
 -> Run `--bar-size <size>` directly.
 -> Confirm: "Bar size set to **<size>**. The status line will update on the next refresh."
+
+If $ARGUMENTS matches `max-width <number>` (where number is 20–100):
+-> Run `--max-width <number>` directly.
+-> Confirm: "Max width set to **<number>%** of terminal. The status line will update on the next refresh."
 
 If $ARGUMENTS matches `bar-style <name>` or `style <name>` (where name is `classic`, `block`, `shade`, `pipe`, `dot`, `square`, or `star`):
 -> Run `--bar-style <name>` directly.
@@ -193,10 +197,12 @@ multiSelect: false
 Options:
   - "Medium (Recommended)" — "8 characters — balanced default"
   - "Small" — "4 characters — compact, more room for text"
+  - "Small-Medium" — "6 characters — between compact and balanced"
+  - "Medium-Large" — "10 characters — slightly wider than default"
   - "Large" — "12 characters — wide bars, more visual detail"
 ```
 
-Apply with `--bar-size <small|medium|large>`.
+Apply with `--bar-size <small|small-medium|medium|medium-large|large>`.
 
 **Step 7:** Check extra credits status by running `python "[REPLACE_WITH_YOUR_PATH]/claude_status.py" --config` silently and checking the "Extra Credits" section.
 


### PR DESCRIPTION
## Summary
- Add `small-medium` (6 chars) and `medium-large` (10 chars) bar sizes (closes #11)
- Detect SSL certificate verification errors with platform-specific fix message on macOS (closes #10)
- Cap status line to 80% of terminal width by default, with `--max-width` flag for customisation (closes #9)