### PR TITLE
Fixes #23 - updated pro model tier variable name

### DIFF
--- a/claude_status.py
+++ b/claude_status.py
@@ -106,7 +106,7 @@ THEMES = {
 }
 
 PLAN_NAMES = {
-    "default_claude_pro": "Pro",
+    "default_claude_ai": "Pro",
     "default_claude_max_5x": "Max 5x",
     "default_claude_max_20x": "Max 20x",
 }


### PR DESCRIPTION
**Summary:**
Adds "default_claude_ai" to the PLAN_NAMES dictionary so users on this plan see "Pro" instead of "Ai" label. 

**Problem:**
The rateLimitTier value default_claude_ai isn't in PLAN_NAMES, so it falls through to the generic formatter:
`PLAN_NAMES.get(tier, _sanitize(tier.replace("default_claude_", "").replace("_", " ").title()))`

Resulting in `"default_claude_ai" → "ai" → "Ai"`. This renders as "Ai" in the status line, which looks like a bug.

Suspect that Anthropic recently changed the `rateLimitTier` for pro model user to `default_claude_ai` instead of `default_claude_pro`.

**Notes:**
Not sure of the official marketing name for this tier — "Claude AI" is a reasonable guess. Happy to update the label if the maintainer knows the correct name.