### PR TITLE
Fix rate-limit death spiral by caching error responses

### DIFF
--- a/claude_status.py
+++ b/claude_status.py
@@ -3242,6 +3242,9 @@ def main():
                 line = line + f" {BRIGHT_YELLOW}{milestone}{RESET}"
         except Exception:
             pass
+    else:
+        # Cache error lines so we don't hammer the API on every refresh
+        write_cache(cache_path, line)
     line = append_update_indicator(line, config)
     line = append_claude_update_indicator(line, config)
     line = _truncate_line(line, config)


### PR DESCRIPTION
## Summary

- When the Anthropic usage API returns a non-401/non-403 error (e.g. **429 rate limit**, 500, 502), the error line is not cached
- This means every status line refresh makes a fresh API call, gets rate-limited again, and repeats — creating a **death spiral** that keeps the user locked out of the usage API
- The fix caches error lines with the same TTL as successful responses (default 60s), so the script backs off before retrying

## The bug

In `main()` around line 3235, only successful responses (`usage is not None`) are cached via `write_cache()`. Error paths set `usage = None` and the line string (e.g. `"API error: 429"`), but that line is never written to cache. On the next refresh (every few seconds), the cache is empty, so the script calls `fetch_usage()` again immediately.

## The fix

Add an `else` branch to also cache error lines:

```python
    else:
        # Cache error lines so we don't hammer the API on every refresh
        write_cache(cache_path, line)
```

This is consistent with how the "no credentials" error path already works (line ~3106), which does call `write_cache()`.

## How I found it

Hit `API error: 429` in my status line that wouldn't clear. Traced it to the missing cache write on error paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)