### PR TITLE
fix: restore Python 3.11 compatibility (backslash in f-string)

### DIFF
--- a/claude_status.py
+++ b/claude_status.py
@@ -2781,7 +2781,8 @@ def cmd_stats():
                 f"{BRIGHT_YELLOW}{cost_str:<12}{RESET}{DIM}({tok_str}){RESET}"
             )
 
-        utf8_print(f"    {DIM}{'\u2500' * 33}{RESET}")
+        _sep = '\u2500' * 33
+        utf8_print(f"    {DIM}{_sep}{RESET}")
         total_local = cost_data["total_cost_usd"] * rate
         utf8_print(f"    {'Total:':<{max_name_len + 2}}  {BOLD}{BRIGHT_YELLOW}{currency_sym}{total_local:,.2f}{RESET}")
         utf8_print("")


### PR DESCRIPTION
## Summary

- Fix `SyntaxError` on Python < 3.12 caused by a backslash inside an f-string expression at line 2784
- Extract the separator string into a local variable before using it in the f-string
- No behaviour change

## Root cause

Python 3.11 and earlier do not allow backslash characters inside f-string expression braces (`{}`):

```python
# Fails on Python < 3.12
utf8_print(f"    {DIM}{chr(0x2500) * 33}{RESET}")
```

Python 3.12 relaxed this restriction (PEP 701). The fix extracts the expression into a variable first:

```python
_sep = chr(0x2500) * 33
utf8_print(f"    {DIM}{_sep}{RESET}")
```

## Test plan

- [ ] `python3.11 -c "import ast; ast.parse(open('claude_status.py').read()); print('OK')"` passes
- [ ] `python3 claude_status.py --version` runs without error
