### PR TITLE
Fix peak hours showing on weekends

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,10 +130,11 @@ Use `/pulse` in Claude Code for an interactive setup wizard, or configure direct
 # Currency (auto-converts USD via live exchange rate)
 --currency £               # $, £, €, ¥, C$, A$, ₹, kr, and 20+ more
 
-# Peak hours (local time) — red in peak, green off-peak
+# Peak hours (local time, weekdays only — Sat/Sun always off-peak per Anthropic policy)
 --peak-hours 13:00-19:00   # Set your peak window
 --peak-hours off           # Disable peak indicator
 # Set "display": "minimal" in config for short format (⚡ Peak 2h)
+# Set "weekdays_only": false in config to show the window every day
 
 # Clock
 --clock-format 12h         # 12h or 24h

--- a/claude_status.py
+++ b/claude_status.py
@@ -900,6 +900,7 @@ def load_config():
     peak.setdefault("enabled", True)
     peak.setdefault("start", "13:00")
     peak.setdefault("end", "19:00")
+    peak.setdefault("weekdays_only", True)
     data["peak_hours"] = peak
     show = data.get("show", {})
     for key, default in DEFAULT_SHOW.items():
@@ -2348,6 +2349,10 @@ def _check_peak_hours(config):
       In peak:      '⚡ Peak 2h'
       Approaching:  '⚡ 45m'
       Off-peak:     '✓ Off-Peak'
+
+    Per Anthropic's published policy, peak applies on weekdays only — Saturdays
+    and Sundays are always off-peak. Users can opt out by setting
+    peak_hours.weekdays_only = false in their config.
     """
     peak = config.get("peak_hours", {})
     if not peak.get("enabled", True):
@@ -2358,9 +2363,13 @@ def _check_peak_hours(config):
         clock = config.get("clock_format", "12h")
         display_mode = peak.get("display", DEFAULT_PEAK_DISPLAY)
         minimal = display_mode == "minimal"
+        weekdays_only = peak.get("weekdays_only", True)
         sh, sm = int(start_str.split(":")[0]), int(start_str.split(":")[1])
         eh, em = int(end_str.split(":")[0]), int(end_str.split(":")[1])
         now = datetime.now()
+        # Mon=0..Fri=4 weekdays; Sat=5, Sun=6 weekends.
+        if weekdays_only and now.weekday() >= 5:
+            return False, "✓ Off-Peak" if minimal else "Off-Peak ✓"
         now_mins = now.hour * 60 + now.minute
         start_mins = sh * 60 + sm
         end_mins = eh * 60 + em

--- a/config.json
+++ b/config.json
@@ -16,7 +16,8 @@
   "peak_hours": {
     "enabled": true,
     "start": "13:00",
-    "end": "19:00"
+    "end": "19:00",
+    "weekdays_only": true
   },
   "show": {
     "session": true,


### PR DESCRIPTION
## Summary

- Peak indicator was comparing clock time only, so any weekend afternoon inside the configured window incorrectly showed **In Peak ⚡**.
- Per Anthropic's published policy ([support.claude.com](https://support.claude.com/en/articles/9797557-usage-limit-best-practices)), peak applies on **weekdays only** — Saturdays and Sundays are always off-peak everywhere in the world.
- Adds `weekdays_only` config option (default `true`) so power-users with personal "burn-rate" windows can opt out.

Closes #37.

## What changed

| File | Change |
|------|--------|
| `claude_status.py` | `_check_peak_hours` now returns Off-Peak if `now.weekday() >= 5` (Sat/Sun) when `weekdays_only` is enabled. `load_config` defaults the new field to `true`. |
| `config.json` | Adds `"weekdays_only": true` to the example. |
| `README.md` | Documents weekday-only behavior + opt-out. |

## Cross-platform

`datetime.now().weekday()` is pure Python — identical Mon=0..Sun=6 semantics on Windows, macOS, and Linux. Uses the same local-timezone source as the existing time-of-day check, so behavior stays consistent across DST and locale changes. No new OS-specific code.

## Backwards compatibility

Existing user configs without the new field get `true` defaulted in via `setdefault` on next load, which matches Anthropic's actual policy. No migration needed.

## Test plan

Verified across 10 scenarios:

- [x] **Sat 13:47** (the reported bug case) → `Off-Peak ✓`
- [x] **Sat 13:47** with `weekdays_only: false` → `In Peak ⚡` (opt-out works)
- [x] **Sun 15:00** → `Off-Peak ✓`
- [x] **Mon 14:00** → `In Peak ⚡ 5h 0m left`
- [x] **Fri 18:30** → `In Peak ⚡ 30m left`
- [x] **Fri 23:00** → `Off-Peak ✓`
- [x] **Sat 13:47** minimal display mode → `✓ Off-Peak`
- [x] **Sat 13:47** with absent config key → `Off-Peak ✓` (default = true)
- [x] **Sun 11:30** (90m before peak) → no "approaching" hint (correct, it's still Sunday)
- [x] **Fri 11:30** (90m before peak) → `Peak ⚡ in 1h 30m` (approaching still works on weekdays)
- [x] Python 3.11 syntax-parse clean (no f-string backslashes — keeps PR #38 happy)