### PR TITLE
Install /pulse command from --install, not just the shell scripts

### DIFF
--- a/claude_status.py
+++ b/claude_status.py
@@ -3955,6 +3955,32 @@ def install_status_line():
     utf8_print("Tip: use --animate on for always-on rainbow animation.")
 
 
+def install_pulse_command():
+    """Copy the /pulse slash command into the user's Claude commands dir.
+
+    The shell installers already do this, but running ``--install`` directly
+    used to set up the status line while leaving ``/pulse`` uninstalled -- the
+    meter worked yet the command silently did nothing.  Making --install
+    self-sufficient closes that gap no matter how the user installed.
+    """
+    source = Path(__file__).resolve().parent / "pulse.md"
+    if not source.exists():
+        utf8_print("Note: pulse.md not found next to claude_status.py; skipped installing the /pulse command.")
+        utf8_print("      Re-run the full installer (install.sh / install.ps1) to add it.")
+        return
+
+    commands_dir = Path.home() / ".claude" / "commands"
+    dest = commands_dir / "pulse.md"
+    try:
+        _secure_mkdir(commands_dir)
+        shutil.copyfile(source, dest)
+    except OSError as e:
+        utf8_print(f"Note: could not install the /pulse command: {e}")
+        return
+
+    utf8_print(f"Installed /pulse command to {dest}")
+
+
 # ---------------------------------------------------------------------------
 # CLI commands
 # ---------------------------------------------------------------------------
@@ -4312,6 +4338,7 @@ def main():
 
     if "--install" in args:
         install_status_line()
+        install_pulse_command()
         return
 
     if "--preset" in args:

--- a/tests/test_install_command.py
+++ b/tests/test_install_command.py
@@ -1,0 +1,60 @@
+"""Regression test: `claude_status.py --install` must install BOTH pieces.
+
+Before this guard, running ``--install`` directly wrote the status-line into
+settings.json but never copied the ``/pulse`` slash command into
+``~/.claude/commands/``.  The meter worked while ``/pulse`` silently did
+nothing.  This test pins both halves of a full install.
+
+Run: ``python tests/test_install_command.py``
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "claude_status.py"
+PULSE_SRC = REPO_ROOT / "pulse.md"
+
+
+class InstallCommandTest(unittest.TestCase):
+    def test_install_sets_up_statusline_and_pulse_command(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            env = dict(os.environ)
+            # Point every home indicator at the sandbox so Path.home()/
+            # expanduser("~") resolve inside it on both Windows and POSIX.
+            env["HOME"] = str(home)
+            env["USERPROFILE"] = str(home)
+            env.pop("HOMEDRIVE", None)
+            env.pop("HOMEPATH", None)
+            env.pop("CLAUDE_CONFIG_DIR", None)
+
+            result = subprocess.run(
+                [sys.executable, str(SCRIPT), "--install"],
+                env=env,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+            settings = home / ".claude" / "settings.json"
+            self.assertTrue(settings.exists(), "settings.json was not written")
+            data = json.loads(settings.read_text(encoding="utf-8"))
+            self.assertIn("statusLine", data)
+            self.assertIn("claude_status.py", data["statusLine"]["command"])
+
+            command = home / ".claude" / "commands" / "pulse.md"
+            self.assertTrue(command.exists(), "/pulse command was not installed")
+            self.assertEqual(
+                command.read_text(encoding="utf-8"),
+                PULSE_SRC.read_text(encoding="utf-8"),
+                "/pulse command content does not match source pulse.md",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Running `claude_status.py --install` directly sets up the status-bar line in `settings.json` but never copies the `/pulse` slash command into `~/.claude/commands/`. Anyone who installs that way — or via an older install script — ends up with a working meter and a **dead `/pulse`** (typing it shows nothing). The shell installers copy the command in a separate step, so the gap is invisible unless that step is bypassed.

## Fix

Make `--install` self-sufficient: after writing the status line it now also installs `pulse.md` into `~/.claude/commands/`, with a graceful note if the file isn't found next to the script. This makes the slash command appear no matter how the user installed.

## Test

Adds `tests/test_install_command.py` — runs `--install` in a sandboxed HOME and asserts **both** the status line and the `/pulse` command land. Verified failing before the fix, passing after.

```
Ran 1 test in 0.139s
OK
```

Meter render and full-script compile confirmed unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)