### PR TITLE
Add live arrow-key theme picker (--pick-theme)

### DIFF
--- a/claude_status.py
+++ b/claude_status.py
@@ -4122,6 +4122,157 @@ def cmd_set_theme(name):
     utf8_print(f"Theme set to {BOLD}{name}{RESET}  {preview}")
 
 
+REVERSE = "\033[7m"  # reverse video — highlights the selected row in the picker
+
+
+def _enable_windows_ansi():
+    """Enable ANSI/VT processing on the Windows console so the picker renders.
+
+    Windows Terminal enables this by default; legacy conhost does not. Modern
+    Windows (10+) supports ENABLE_VIRTUAL_TERMINAL_PROCESSING (0x0004).
+    """
+    if sys.platform != "win32":
+        return
+    try:
+        import ctypes
+        kernel32 = ctypes.windll.kernel32
+        handle = kernel32.GetStdHandle(-11)  # STD_OUTPUT_HANDLE
+        mode = ctypes.c_uint32()
+        if kernel32.GetConsoleMode(handle, ctypes.byref(mode)):
+            kernel32.SetConsoleMode(handle, mode.value | 0x0004)
+    except Exception:
+        os.system("")  # last-resort: spawning a shell flips VT on as a side effect
+
+
+def _read_key():
+    """Block for a single keypress and return a normalised token.
+
+    Returns one of: 'up', 'down', 'enter', 'esc', 'ctrl-c', or the literal
+    character pressed (e.g. 'q', 'k'). Arrow keys differ by platform: Windows
+    sends a '\\x00'/'\\xe0' prefix then a letter; POSIX sends an ESC '[' sequence.
+    """
+    if sys.platform == "win32":
+        import msvcrt
+        ch = msvcrt.getwch()
+        if ch in ("\x00", "\xe0"):  # special-key prefix; the real code follows
+            code = msvcrt.getwch()
+            return {"H": "up", "P": "down", "K": "left", "M": "right"}.get(code, "")
+        if ch in ("\r", "\n"):
+            return "enter"
+        if ch == "\x1b":
+            return "esc"
+        if ch == "\x03":
+            return "ctrl-c"
+        return ch
+    # POSIX
+    import termios
+    import tty
+    import select
+    fd = sys.stdin.fileno()
+    old = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        ch = sys.stdin.read(1)
+        if ch == "\x1b":
+            # Could be a lone ESC or the start of an arrow sequence — peek briefly.
+            ready, _, _ = select.select([sys.stdin], [], [], 0.03)
+            if not ready:
+                return "esc"
+            if sys.stdin.read(1) == "[":
+                code = sys.stdin.read(1)
+                return {"A": "up", "B": "down", "C": "right", "D": "left"}.get(code, "")
+            return "esc"
+        if ch in ("\r", "\n"):
+            return "enter"
+        if ch == "\x03":
+            return "ctrl-c"
+        return ch
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old)
+
+
+def _render_picker(names, cursor, current_theme, bar_size, bar_style):
+    """Build the full picker screen: one live status-line preview per theme,
+    with the cursor row highlighted in reverse video."""
+    demo_usage = {
+        "five_hour": {"utilization": 42, "resets_at": None},
+        "seven_day": {"utilization": 67, "resets_at": None},
+    }
+    lines = [
+        "",
+        f"  {BOLD}Pick a theme{RESET}   {DIM}↑/↓ move · Enter keep · Esc cancel{RESET}",
+        f"  {DIM}{'─' * 60}{RESET}",
+    ]
+    for i, name in enumerate(names):
+        demo_tc = THEME_DEMO_TEXT.get(name, "white")
+        demo_config = {
+            "theme": name, "bar_size": bar_size, "bar_style": bar_style,
+            "text_color": demo_tc,
+            "show": {"session": True, "weekly": True, "plan": True, "timer": False,
+                     "extra": False, "sparkline": False, "runway": False,
+                     "status_message": False, "streak": False, "model": False, "context": False},
+        }
+        preview = build_status_line(demo_usage, "Max 20x", demo_config)
+        tag = f" {GREEN}(current){RESET}" if name == current_theme else ""
+        if i == cursor:
+            label = f"{BOLD}▸{RESET} {REVERSE}{BOLD} {name:<8} {RESET}"
+        else:
+            label = f"  {BOLD} {name:<8} {RESET}"
+        lines.append(f"  {label} {preview}{tag}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def cmd_pick_theme():
+    """Interactive arrow-key theme picker with a live status-line preview.
+
+    Requires an interactive terminal. When stdin/stdout is not a TTY (e.g. run
+    through a tool that captures output) it falls back to the static gallery so
+    nothing crashes and the user can still pick with ``--theme <name>``.
+    """
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        cmd_themes_demo()
+        utf8_print(f"  {DIM}The live picker needs an interactive terminal. "
+                   f"Pick one above and set it with:  --theme <name>{RESET}")
+        return
+
+    _enable_windows_ansi()
+
+    config = load_config()
+    current_theme = config.get("theme", "default")
+    bar_size = config.get("bar_size", DEFAULT_BAR_SIZE)
+    bar_style = config.get("bar_style", DEFAULT_BAR_STYLE)
+    names = list(THEMES.keys())
+    cursor = names.index(current_theme) if current_theme in names else 0
+
+    def _w(text):
+        sys.stdout.buffer.write(text.encode("utf-8"))
+        sys.stdout.flush()
+
+    chosen = None
+    _w("\x1b[?1049h\x1b[?25l")  # enter alternate screen + hide cursor
+    try:
+        while True:
+            _w("\x1b[H\x1b[J" + _render_picker(names, cursor, current_theme, bar_size, bar_style))
+            key = _read_key()
+            if key in ("up", "k"):
+                cursor = (cursor - 1) % len(names)
+            elif key in ("down", "j"):
+                cursor = (cursor + 1) % len(names)
+            elif key == "enter":
+                chosen = names[cursor]
+                break
+            elif key in ("esc", "ctrl-c", "q"):
+                break
+    finally:
+        _w("\x1b[?25h\x1b[?1049l")  # show cursor + leave alternate screen
+
+    if chosen:
+        cmd_set_theme(chosen)  # handles default→factory-reset, cache clear, confirmation
+    else:
+        utf8_print("Theme unchanged.")
+
+
 def cmd_show(parts_str):
     """Enable the given comma-separated parts."""
     config = load_config()
@@ -4365,6 +4516,10 @@ def main():
 
     if "--themes-demo" in args:
         cmd_themes_demo()
+        return
+
+    if "--pick-theme" in args or "--pick" in args:
+        cmd_pick_theme()
         return
 
     if "--themes" in args:

--- a/commands/pulse.md
+++ b/commands/pulse.md
@@ -20,6 +20,13 @@ If $ARGUMENTS matches a **theme name** (`default`, `ocean`, `sunset`, `mono`, `n
 -> Run `python "SCRIPT_PATH" --theme <name>` directly, no menu.
 -> Confirm: "Theme set to **<name>**. The status line will update on the next refresh."
 
+If $ARGUMENTS is `pick`, `picker`, or `pick-theme`:
+-> This is the **live arrow-key theme picker**: one screen, scroll through all 10 themes, and the status-bar preview recolours live. It needs an interactive terminal, so the **user must launch it themselves** — you cannot drive the keypresses for them.
+-> Tell the user to type this in their prompt to launch it:
+   `!python "SCRIPT_PATH" --pick-theme`
+-> Explain the controls in one line: "↑/↓ (or j/k) to move · Enter to keep · Esc to cancel — your bar recolours live as you move."
+-> Add the fallback note: "If you see a static coloured list instead of a moving cursor, this terminal isn't interactive here — just note the name you like and run `/pulse <name>`."
+
 If $ARGUMENTS is `config` or `settings`:
 -> Run `python "SCRIPT_PATH" --config` silently.
 -> Summarise the settings in your response text (don't show raw ANSI output).
@@ -100,7 +107,13 @@ Run `python "SCRIPT_PATH" --config` silently to check for updates.
 
 **Step 1:** Run `python "SCRIPT_PATH" --themes-demo` and show the output.
 
-**Step 2:** Theme picker (paginated as 3 pages):
+**Step 2:** Theme — offer the **live picker** first.
+
+Say: "For the best experience, launch the live picker — type  `!python "SCRIPT_PATH" --pick-theme`  in your prompt. Arrow keys move through all 10 themes, your bar recolours live, Enter keeps it, Esc cancels. (If it shows a static list instead of a moving cursor, this terminal isn't interactive — use the quick picker below.)"
+
+If the user would rather pick from a list right here (or the live picker isn't available in their terminal), use the paginated picker below.
+
+Theme picker (paginated as 3 pages):
 
 Page 1:
 ```

--- a/pulse.md
+++ b/pulse.md
@@ -20,6 +20,13 @@ If $ARGUMENTS matches a **theme name** (`default`, `ocean`, `sunset`, `mono`, `n
 -> Run `python "SCRIPT_PATH" --theme <name>` directly, no menu.
 -> Confirm: "Theme set to **<name>**. The status line will update on the next refresh."
 
+If $ARGUMENTS is `pick`, `picker`, or `pick-theme`:
+-> This is the **live arrow-key theme picker**: one screen, scroll through all 10 themes, and the status-bar preview recolours live. It needs an interactive terminal, so the **user must launch it themselves** — you cannot drive the keypresses for them.
+-> Tell the user to type this in their prompt to launch it:
+   `!python "SCRIPT_PATH" --pick-theme`
+-> Explain the controls in one line: "↑/↓ (or j/k) to move · Enter to keep · Esc to cancel — your bar recolours live as you move."
+-> Add the fallback note: "If you see a static coloured list instead of a moving cursor, this terminal isn't interactive here — just note the name you like and run `/pulse <name>`."
+
 If $ARGUMENTS is `config` or `settings`:
 -> Run `python "SCRIPT_PATH" --config` silently.
 -> Summarise the settings in your response text (don't show raw ANSI output).
@@ -100,7 +107,13 @@ Run `python "SCRIPT_PATH" --config` silently to check for updates.
 
 **Step 1:** Run `python "SCRIPT_PATH" --themes-demo` and show the output.
 
-**Step 2:** Theme picker (paginated as 3 pages):
+**Step 2:** Theme — offer the **live picker** first.
+
+Say: "For the best experience, launch the live picker — type  `!python "SCRIPT_PATH" --pick-theme`  in your prompt. Arrow keys move through all 10 themes, your bar recolours live, Enter keeps it, Esc cancels. (If it shows a static list instead of a moving cursor, this terminal isn't interactive — use the quick picker below.)"
+
+If the user would rather pick from a list right here (or the live picker isn't available in their terminal), use the paginated picker below.
+
+Theme picker (paginated as 3 pages):
 
 Page 1:
 ```

--- a/tests/test_pick_theme.py
+++ b/tests/test_pick_theme.py
@@ -1,0 +1,115 @@
+"""Tests for the interactive arrow-key theme picker (``--pick-theme``).
+
+The picker needs a real terminal, so these tests drive it without one:
+
+* the navigation loop is exercised by feeding a scripted key sequence into a
+  patched ``_read_key`` and asserting which theme gets applied;
+* the Windows arrow-key decoding (the ``\\xe0`` prefix + letter codes) is
+  verified by patching ``msvcrt.getwch`` (Windows only);
+* ``_render_picker`` is checked for the selection highlight and current marker;
+* the no-TTY path is checked to fall back to the static gallery, not crash.
+
+Run: ``python tests/test_pick_theme.py``
+"""
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import claude_status as cs  # noqa: E402
+
+
+class PickerLoopTest(unittest.TestCase):
+    """The down/down/Enter dance should apply the third theme in the list."""
+
+    def _run_with_keys(self, keys):
+        """Drive cmd_pick_theme with a scripted key sequence; return the theme
+        passed to cmd_set_theme (or None if it was never called)."""
+        applied = {}
+        key_iter = iter(keys)
+        with mock.patch.object(cs, "_read_key", lambda: next(key_iter)), \
+                mock.patch.object(cs, "_enable_windows_ansi", lambda: None), \
+                mock.patch.object(cs, "load_config", lambda: {"theme": "default"}), \
+                mock.patch.object(cs, "cmd_set_theme",
+                                  side_effect=lambda name: applied.setdefault("name", name)), \
+                mock.patch("sys.stdin") as fake_in, \
+                mock.patch("sys.stdout") as fake_out:
+            fake_in.isatty.return_value = True
+            fake_out.isatty.return_value = True
+            cs.cmd_pick_theme()
+        return applied.get("name")
+
+    def test_arrow_down_then_enter_applies_third_theme(self):
+        names = list(cs.THEMES.keys())
+        chosen = self._run_with_keys(["down", "down", "enter"])
+        self.assertEqual(chosen, names[2],
+                         "two downs from the top should land on the third theme")
+
+    def test_vim_keys_navigate(self):
+        names = list(cs.THEMES.keys())
+        chosen = self._run_with_keys(["j", "enter"])  # j == down
+        self.assertEqual(chosen, names[1])
+
+    def test_up_wraps_to_last_theme(self):
+        names = list(cs.THEMES.keys())
+        chosen = self._run_with_keys(["up", "enter"])  # up from index 0 wraps
+        self.assertEqual(chosen, names[-1])
+
+    def test_esc_cancels_without_applying(self):
+        self.assertIsNone(self._run_with_keys(["down", "esc"]),
+                          "Esc must not apply any theme")
+
+    def test_ctrl_c_cancels_without_applying(self):
+        self.assertIsNone(self._run_with_keys(["down", "ctrl-c"]))
+
+
+class RenderPickerTest(unittest.TestCase):
+    def test_cursor_row_is_highlighted_and_current_is_marked(self):
+        names = list(cs.THEMES.keys())
+        out = cs._render_picker(names, cursor=1, current_theme=names[0],
+                                bar_size="large", bar_style="classic")
+        self.assertIn("Pick a theme", out)
+        self.assertIn(cs.REVERSE, out, "selected row should use reverse video")
+        self.assertIn("(current)", out, "the active theme should be marked current")
+        # Every theme name appears exactly as a label.
+        for name in names:
+            self.assertIn(name, out)
+
+
+class NoTtyFallbackTest(unittest.TestCase):
+    def test_falls_back_to_gallery_without_a_terminal(self):
+        with mock.patch.object(cs, "cmd_themes_demo") as demo, \
+                mock.patch("sys.stdin") as fake_in, \
+                mock.patch("sys.stdout") as fake_out:
+            fake_in.isatty.return_value = False
+            fake_out.isatty.return_value = True
+            cs.cmd_pick_theme()
+        demo.assert_called_once()
+
+
+@unittest.skipUnless(sys.platform == "win32", "Windows-specific key decoding")
+class WindowsKeyDecodeTest(unittest.TestCase):
+    def _decode(self, chars):
+        import msvcrt
+        seq = iter(chars)
+        with mock.patch.object(msvcrt, "getwch", lambda: next(seq)):
+            return cs._read_key()
+
+    def test_arrow_up(self):
+        self.assertEqual(self._decode(["\xe0", "H"]), "up")
+
+    def test_arrow_down(self):
+        self.assertEqual(self._decode(["\x00", "P"]), "down")  # both prefixes occur
+
+    def test_enter_esc_and_literal(self):
+        self.assertEqual(self._decode(["\r"]), "enter")
+        self.assertEqual(self._decode(["\x1b"]), "esc")
+        self.assertEqual(self._decode(["\x03"]), "ctrl-c")
+        self.assertEqual(self._decode(["q"]), "q")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Replaces the multi-page, text-only theme menu with a **single-screen interactive picker**. Scroll all 10 themes with arrow keys (or `j`/`k`), each rendered as a live status-line preview in its **real colours**, **Enter** to keep, **Esc** to cancel — the standard set by `theme.sh` and Gemini CLI's `/theme`: show the real thing, pick it in place.

## Why

The old picker showed a colour gallery in one place, then asked you to choose from a separate text-only menu capped at 4 options — so the 10 themes were split across 3 "More themes…" clicks, with colours described in words you'd just seen. This unifies "see it" and "pick it".

## How

- **New `--pick-theme`** mode (`/pulse pick` route added; the setup menu now leads with it, paginated list kept as fallback).
- **Cross-platform key handling**: Windows `\xe0`-prefixed arrow codes via `msvcrt`; POSIX escape sequences via `termios` with an ESC-vs-sequence timeout. ANSI/VT enabled on the Windows console.
- **Graceful no-TTY fallback** to the static gallery, so any output-capturing wrapper never crashes.

## Tests

New `tests/test_pick_theme.py` covers the navigation loop (down/down/Enter → third theme), vim keys, wrap-around, Esc/Ctrl-C cancel, the render highlight + current marker, the no-TTY fallback, and Windows arrow decoding. All green; existing install test and normal status render unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)