### PR TITLE
Harden MiniMax provider and make the status line crash-proof

### DIFF
--- a/claude_status.py
+++ b/claude_status.py
@@ -648,11 +648,9 @@ def _apply_bar_animation(colour, char_idx, bar_width, anim_mode, config=None):
     now = time.time()
 
     if anim_mode == "pulse":
-        # Bar cycles through theme's low → mid → high colours over time
-        # Each frame is a distinctly different colour
-        phase = (now * 0.5 * speed) % 1.0  # slow cycle
-        # Cycle: low(0) → mid(0.33) → high(0.66) → low(1.0)
-        return None  # handled at bar level with _pulse_theme_color
+        # Bar cycles through theme's low → mid → high colours over time;
+        # the actual cycling is handled at bar level with _pulse_theme_color.
+        return None
 
     elif anim_mode == "glow":
         # Each character is a different colour — gradient across the bar
@@ -1785,23 +1783,33 @@ def _parse_minimax_quota(mmx_json):
     the user hasn't generated any video).
     """
     out = {}
+    if not isinstance(mmx_json, dict):
+        return out
     for entry in mmx_json.get("model_remains", []):
-        if entry.get("current_interval_status") == 3:
+        if not isinstance(entry, dict) or entry.get("current_interval_status") == 3:
             continue
         interval_left = entry.get("current_interval_remaining_percent")
         weekly_left   = entry.get("current_weekly_remaining_percent")
         end_ms        = entry.get("end_time")
         weekly_end_ms = entry.get("weekly_end_time")
+        # Guard each bucket independently: a malformed percent or timestamp
+        # in one window must not lose the other (or crash the status line).
         if interval_left is not None and end_ms:
-            out["five_hour"] = {
-                "utilization": 100.0 - float(interval_left),
-                "resets_at":   datetime.fromtimestamp(end_ms / 1000, tz=timezone.utc).isoformat(),
-            }
+            try:
+                out["five_hour"] = {
+                    "utilization": 100.0 - float(interval_left),
+                    "resets_at":   datetime.fromtimestamp(float(end_ms) / 1000, tz=timezone.utc).isoformat(),
+                }
+            except (ValueError, TypeError, OSError, OverflowError):
+                pass
         if weekly_left is not None and weekly_end_ms:
-            out["seven_day"] = {
-                "utilization": 100.0 - float(weekly_left),
-                "resets_at":   datetime.fromtimestamp(weekly_end_ms / 1000, tz=timezone.utc).isoformat(),
-            }
+            try:
+                out["seven_day"] = {
+                    "utilization": 100.0 - float(weekly_left),
+                    "resets_at":   datetime.fromtimestamp(float(weekly_end_ms) / 1000, tz=timezone.utc).isoformat(),
+                }
+            except (ValueError, TypeError, OSError, OverflowError):
+                pass
         break
     return out
 
@@ -2992,46 +3000,54 @@ def _parse_stdin_context(raw_stdin):
         pass
 
     # MiniMax provider: when running under mxclaude, fix the four known
-    # stdin mismatches described at the top of this provider block.
-    if "minimax.io" in os.environ.get("ANTHROPIC_BASE_URL", "") and \
-       os.environ.get("ANTHROPIC_MODEL", "").startswith("MiniMax-"):
-        ctx = data.get("data", data).get("context_window", {}) or {}
-        in_tok  = int(ctx.get("total_input_tokens")  or 0)
-        out_tok = int(ctx.get("total_output_tokens") or 0)
-        total   = in_tok + out_tok
+    # stdin mismatches described at the top of this provider block. Wrapped
+    # like every sibling block above so malformed stdin can never crash the
+    # status line — on any error we simply leave the Anthropic-shaped values.
+    try:
+        if "minimax.io" in os.environ.get("ANTHROPIC_BASE_URL", "") and \
+           os.environ.get("ANTHROPIC_MODEL", "").startswith("MiniMax-"):
+            ctx = data.get("data", data).get("context_window", {}) or {}
+            in_tok  = int(ctx.get("total_input_tokens")  or 0)
+            out_tok = int(ctx.get("total_output_tokens") or 0)
+            total   = in_tok + out_tok
 
-        # 1 + 2: Recompute Context %% from (input + output) against the
-        # real per-model window (don't trust the shim's stdin value).
-        ctx_size = MINIMAX_CONTEXT_SIZES.get(
-            os.environ["ANTHROPIC_MODEL"], 1_000_000,
-        )
-        if ctx_size > 0:
-            result["context_pct"] = (total / ctx_size) * 100.0
+            # 1 + 2: Recompute Context %% from (input + output) against the
+            # real per-model window (don't trust the shim's stdin value), and
+            # keep tokens-display mode consistent with the corrected window.
+            ctx_size = MINIMAX_CONTEXT_SIZES.get(
+                os.environ.get("ANTHROPIC_MODEL", ""), 1_000_000,
+            )
+            if ctx_size > 0:
+                result["context_pct"] = (total / ctx_size) * 100.0
+                result["context_used"] = total
+                result["context_limit"] = ctx_size
 
-        # 3: Recompute cost from token counts using tiered pricing.
-        # Anthropic-priced `cost.total_cost_usd` is wrong under mxclaude.
-        tier = MINIMAX_PRICING["tier1"]
-        if total > MINIMAX_PRICING["tier1"]["max_tokens"]:
-            tier = MINIMAX_PRICING["tier2"]
-        result["cost_usd"] = (
-            in_tok  * tier["in_per_m"] / 1_000_000.0
-            + out_tok * tier["out_per_m"] / 1_000_000.0
-        )
+            # 3: Recompute cost from token counts using tiered pricing.
+            # Anthropic-priced `cost.total_cost_usd` is wrong under mxclaude.
+            tier = MINIMAX_PRICING["tier1"]
+            if total > MINIMAX_PRICING["tier1"]["max_tokens"]:
+                tier = MINIMAX_PRICING["tier2"]
+            result["cost_usd"] = (
+                in_tok  * tier["in_per_m"] / 1_000_000.0
+                + out_tok * tier["out_per_m"] / 1_000_000.0
+            )
 
-        # 4: Fetch rate_limits from `mmx quota show` and reshape to Pulse's
-        # schema. Only override if stdin didn't already provide rate_limits.
-        if not result.get("_rate_limits"):
-            try:
-                mmx_proc = subprocess.run(
-                    ["mmx", "quota", "show", "--output", "json", "--quiet"],
-                    capture_output=True, text=True, timeout=3,
-                )
-                if mmx_proc.returncode == 0:
-                    parsed = _parse_minimax_quota(json.loads(mmx_proc.stdout))
-                    if parsed:
-                        result["_rate_limits"] = parsed
-            except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
-                pass  # renderer will simply not show rate bars
+            # 4: Fetch rate_limits from `mmx quota show` and reshape to Pulse's
+            # schema. Only override if stdin didn't already provide rate_limits.
+            if not result.get("_rate_limits"):
+                try:
+                    mmx_proc = subprocess.run(
+                        ["mmx", "quota", "show", "--output", "json", "--quiet"],
+                        capture_output=True, text=True, timeout=3,
+                    )
+                    if mmx_proc.returncode == 0:
+                        parsed = _parse_minimax_quota(json.loads(mmx_proc.stdout))
+                        if parsed:
+                            result["_rate_limits"] = parsed
+                except (subprocess.TimeoutExpired, FileNotFoundError, json.JSONDecodeError):
+                    pass  # renderer will simply not show rate bars
+    except (AttributeError, KeyError, ValueError, TypeError, OSError):
+        pass
 
     return result
 
@@ -5170,7 +5186,6 @@ def main():
     # Normal status line mode
     config = load_config()
     cache_ttl = config.get("cache_ttl_seconds", DEFAULT_CACHE_TTL)
-    animate = config.get("animate", "off")
 
     # Note: _detect_status_bar_conflict() removed — it suppressed all output
     # when leftover npm @anthropic-ai/claude-code files existed on disk,
@@ -5387,4 +5402,21 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    try:
+        main()
+    except KeyboardInterrupt:
+        raise SystemExit(130)
+    except Exception:
+        # A status line must never crash Claude Code with a traceback. When
+        # invoked as the status line (stdin is piped, not a TTY) degrade to a
+        # clean blank line; for interactive CLI use, surface the error.
+        try:
+            interactive = sys.stdin.isatty()
+        except Exception:
+            interactive = False
+        if interactive:
+            raise
+        try:
+            sys.stdout.buffer.write((RESET + "\n").encode("utf-8"))
+        except Exception:
+            pass

--- a/tests/test_minimax_provider.py
+++ b/tests/test_minimax_provider.py
@@ -1,0 +1,148 @@
+"""Tests for the optional MiniMax provider extension (PR #43).
+
+When Claude Code is pointed at MiniMax's Anthropic-compatible endpoint via
+``mxclaude``, four stdin fields don't describe the session correctly. The
+provider block in ``_parse_stdin_context`` corrects them, gated on the
+``ANTHROPIC_BASE_URL`` / ``ANTHROPIC_MODEL`` env vars.
+
+These tests pin three things:
+
+* the env gate (the block must be inert for normal Anthropic sessions);
+* the corrections (context %, cost, token counts, rate-limit reshape);
+* robustness — malformed stdin or quota JSON must never raise, because a
+  status line that throws crashes Claude Code's status bar.
+
+Run: ``python tests/test_minimax_provider.py``
+"""
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import claude_status as cs  # noqa: E402
+
+
+MINIMAX_ENV = {
+    "ANTHROPIC_BASE_URL": "https://api.minimax.io/anthropic",
+    "ANTHROPIC_MODEL": "MiniMax-M3",
+}
+
+
+def _stdin(input_tokens, output_tokens, used_percentage=12.0, cost=9.99):
+    """Build a Claude Code stdin JSON blob with a context_window + cost."""
+    return json.dumps({
+        "context_window": {
+            "used_percentage": used_percentage,
+            "total_input_tokens": input_tokens,
+            "total_output_tokens": output_tokens,
+            "context_window_size": 200_000,  # the shim's wrong value
+        },
+        "cost": {"total_cost_usd": cost},
+    })
+
+
+class QuotaParserTest(unittest.TestCase):
+    def test_happy_path_maps_both_windows(self):
+        out = cs._parse_minimax_quota({
+            "model_remains": [{
+                "current_interval_status": 1,
+                "current_interval_remaining_percent": 19.0,   # → 81% used
+                "current_weekly_remaining_percent": 87.0,     # → 13% used
+                "end_time": 1_900_000_000_000,                # ms epoch
+                "weekly_end_time": 1_900_500_000_000,
+            }],
+        })
+        self.assertAlmostEqual(out["five_hour"]["utilization"], 81.0)
+        self.assertAlmostEqual(out["seven_day"]["utilization"], 13.0)
+        self.assertTrue(out["five_hour"]["resets_at"].startswith("20"))
+
+    def test_skips_unused_bucket_status_3(self):
+        out = cs._parse_minimax_quota({
+            "model_remains": [{
+                "current_interval_status": 3,  # un-used this period → skip
+                "current_interval_remaining_percent": 50.0,
+                "end_time": 1_900_000_000_000,
+            }],
+        })
+        self.assertEqual(out, {})
+
+    def test_malformed_values_do_not_raise(self):
+        # Non-numeric percent / bad timestamp: skip the bucket, never throw.
+        out = cs._parse_minimax_quota({
+            "model_remains": [{
+                "current_interval_status": 1,
+                "current_interval_remaining_percent": "not-a-number",
+                "end_time": "garbage",
+                "current_weekly_remaining_percent": 90.0,
+                "weekly_end_time": 1_900_000_000_000,
+            }],
+        })
+        # five_hour dropped (bad data), seven_day still parsed.
+        self.assertNotIn("five_hour", out)
+        self.assertAlmostEqual(out["seven_day"]["utilization"], 10.0)
+
+    def test_non_dict_input_returns_empty(self):
+        self.assertEqual(cs._parse_minimax_quota([]), {})
+        self.assertEqual(cs._parse_minimax_quota("nope"), {})
+
+
+class StdinGateTest(unittest.TestCase):
+    def test_inactive_without_minimax_env(self):
+        # No MiniMax env → block is inert, Anthropic values pass through.
+        with mock.patch.dict("os.environ", {}, clear=True):
+            res = cs._parse_stdin_context(_stdin(100_000, 50_000, used_percentage=12.0))
+        self.assertAlmostEqual(res["context_pct"], 12.0)   # unchanged
+        self.assertEqual(res["context_limit"], 200_000)     # unchanged
+
+    def test_recomputes_context_cost_and_limit(self):
+        with mock.patch.dict("os.environ", MINIMAX_ENV, clear=True):
+            res = cs._parse_stdin_context(_stdin(100_000, 50_000, used_percentage=12.0, cost=9.99))
+        # 150k / 1M = 15%, not the shim's 12% and not against 200k.
+        self.assertAlmostEqual(res["context_pct"], 15.0)
+        self.assertEqual(res["context_used"], 150_000)
+        self.assertEqual(res["context_limit"], 1_000_000)   # real M3 window
+        # tier1 (≤512k): 100k*0.60/1M + 50k*2.40/1M = 0.06 + 0.12 = 0.18
+        self.assertAlmostEqual(res["cost_usd"], 0.18)
+        self.assertNotAlmostEqual(res["cost_usd"], 9.99)    # not Anthropic price
+
+    def test_tier2_pricing_above_512k(self):
+        with mock.patch.dict("os.environ", MINIMAX_ENV, clear=True):
+            res = cs._parse_stdin_context(_stdin(600_000, 100_000))
+        # total 700k > 512k → tier2: 600k*1.20/1M + 100k*4.80/1M = 0.72 + 0.48
+        self.assertAlmostEqual(res["cost_usd"], 1.20)
+
+    def test_malformed_tokens_do_not_raise(self):
+        bad = json.dumps({"context_window": {"total_input_tokens": "oops"},
+                          "cost": {"total_cost_usd": 1.0}})
+        with mock.patch.dict("os.environ", MINIMAX_ENV, clear=True):
+            res = cs._parse_stdin_context(bad)  # must not raise
+        self.assertIsInstance(res, dict)
+
+    def test_quota_subprocess_populates_rate_limits(self):
+        quota = {"model_remains": [{
+            "current_interval_status": 1,
+            "current_interval_remaining_percent": 20.0,
+            "current_weekly_remaining_percent": 80.0,
+            "end_time": 1_900_000_000_000,
+            "weekly_end_time": 1_900_500_000_000,
+        }]}
+        fake = mock.Mock(returncode=0, stdout=json.dumps(quota))
+        with mock.patch.dict("os.environ", MINIMAX_ENV, clear=True), \
+                mock.patch.object(cs.subprocess, "run", return_value=fake):
+            res = cs._parse_stdin_context(_stdin(10, 10))
+        self.assertAlmostEqual(res["_rate_limits"]["five_hour"]["utilization"], 80.0)
+        self.assertAlmostEqual(res["_rate_limits"]["seven_day"]["utilization"], 20.0)
+
+    def test_missing_mmx_binary_is_silent(self):
+        with mock.patch.dict("os.environ", MINIMAX_ENV, clear=True), \
+                mock.patch.object(cs.subprocess, "run", side_effect=FileNotFoundError):
+            res = cs._parse_stdin_context(_stdin(10, 10))  # must not raise
+        self.assertNotIn("_rate_limits", res)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Follow-up hardening for the MiniMax provider merged in #43, plus a general resilience fix for the status line.

## Why

The MiniMax block was the **only** section of `_parse_stdin_context` not wrapped in `try/except`, and `_parse_minimax_quota` ran `float()` / `datetime.fromtimestamp` on unguarded `mmx quota show` output. A malformed quota response or a non-numeric token count on stdin could raise straight out of the parser — and since `__main__` called `main()` bare, that surfaces as a **Python traceback in Claude Code's status bar**.

## Changes

- **Wrap the MiniMax block** in `try/except` like every sibling block in `_parse_stdin_context`; on any error it leaves the Anthropic-shaped values untouched.
- **Guard each quota bucket independently** in `_parse_minimax_quota` so one bad percent/timestamp can't lose the other window (or crash); reject non-dict JSON up front.
- **Fix `context_used` / `context_limit`** alongside `context_pct` so tokens-display mode also uses the real per-model window (1M for M3) instead of the shim's wrong 200K.
- **Top-level guard in `__main__`**: a status line must never crash Claude Code. Non-TTY (status-line) invocations degrade to a clean blank line; interactive CLI use still surfaces errors.
- Remove two dead locals (`phase`, `animate`) flagged by ruff.

## Tests

New `tests/test_minimax_provider.py` (10 tests): the env gate, all four corrections, tier-1/tier-2 pricing, quota reshaping, and that malformed stdin/quota JSON never raises.

Full suite green (21 tests):
- `test_pick_theme.py` — 10 ok
- `test_install_command.py` — 1 ok
- `test_minimax_provider.py` — 10 ok

End-to-end smoke verified: normal Anthropic session unchanged (42% / $1.23); MiniMax session corrected (10% / $0.10); garbage/empty stdin and a simulated render failure all exit 0 with no traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)