### PR TITLE
v3.2.0 — Fable support, Claude 5-era stdin fields, drop peak hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 </p>
 
 <p align="center">
-  Real-time usage monitor for Claude Code — session limits, weekly limits, cost tracking, peak hours, and 10 themes with animations. All in your status bar.
+  Real-time usage monitor for Claude Code — session limits, weekly limits, per-model caps (Opus/Sonnet/Fable), cost tracking, and 10 themes with animations. All in your status bar.
 </p>
 
 <p align="center">
   <a href="https://github.com/NoobyGains/claude-pulse/stargazers"><img src="https://img.shields.io/github/stars/NoobyGains/claude-pulse?style=social" alt="GitHub Stars" /></a>
   <img src="https://img.shields.io/github/v/tag/NoobyGains/claude-pulse?label=version&color=blue" alt="Version" />
-  <img src="https://img.shields.io/badge/python-3.6+-3776AB?logo=python&logoColor=white" alt="Python 3.6+" />
+  <img src="https://img.shields.io/badge/python-3.8+-3776AB?logo=python&logoColor=white" alt="Python 3.8+" />
   <img src="https://img.shields.io/badge/dependencies-zero-brightgreen" alt="Zero Dependencies" />
   <img src="https://img.shields.io/badge/Claude%20Code-v2.1.80+-7C3AED?logo=anthropic&logoColor=white" alt="Claude Code v2.1.80+" />
   <img src="https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-lightgrey" alt="Platform" />
@@ -42,7 +42,7 @@ A single-file Python status bar for Claude Code that shows everything you need a
 </p>
 
 ```
-Session ━━━───────── 27% 2h 53m | Weekly ━━━━━━━━━─── 73% R:Fri 3pm | Context ━━━━──────── 35% | $38.75 | +142 -37 | In Peak ⚡2x 2h 54m left (1pm-7pm) | Opus 4.6 | [\] 320 tools 51m | main
+Session ━━━───────── 27% 2h 53m | Weekly ━━━━━━━━━─── 73% R:Fri 3pm | Fable ━━───────── 18% | Context ━━━━──────── 35% | $38.75 | +142 -37 | Opus 5 | xh | ⚡fast | [\] 320 tools 51m | main
 ```
 
 ## Features
@@ -52,10 +52,14 @@ Session ━━━───────── 27% 2h 53m | Weekly ━━━━━
 | **Session & Weekly bars** | Colour-coded progress bars (green → yellow → red) for 5-hour session and 7-day weekly limits |
 | **Context window** | Live context usage percentage with pressure warnings at 70%/90% |
 | **Cost tracking** | Real-time session cost in your local currency (USD, GBP, EUR, + 25 more) with live exchange rates |
-| **Peak hours** | Configurable indicator for Anthropic's peak consumption window — red **In Peak ⚡** when limits burn faster, yellow when **approaching**, green **Off-Peak ✓** when limits stretch further. Full and minimal display modes |
+| **Per-model weekly caps** | Separate bars for Opus, Sonnet and **Fable** weekly budgets, read from the model-scoped limits the API reports. Shown only when your plan actually reports them |
+| **Effort & fast mode** | Reasoning effort (`lo`/`med`/`hi`/`xh`/`max`, colour-escalating) and a **⚡fast** badge when Opus fast mode is active |
+| **Subagent & PR** | Active subagent name, plus an opt-in clickable PR badge with review state (OSC 8 hyperlink) |
+| **Cache efficiency** | Opt-in indicator for the share of input served from cache — the clearest cost signal on stdin |
+| **Two-line layout** | Split widgets across two rows with `line1_widgets` / `line2_widgets` |
 | **Live heartbeat** | Spinning indicator with tool count and elapsed time (via PostToolUse hook) |
 | **Git branch** | Current branch name always visible |
-| **Model display** | Shows which model is active (Opus, Sonnet, Haiku) |
+| **Model display** | Shows which model is active (Fable, Opus, Sonnet, Haiku) |
 | **10 themes** | default, ocean, sunset, mono, neon, pride, frost, ember, candy, rainbow |
 | **5 animation modes** | off, rainbow, pulse, glow, shift — each visually distinct |
 | **8 bar styles** | classic, block, shade, pipe, dot, square, star, braille |
@@ -127,14 +131,13 @@ Use `/pulse` in Claude Code for an interactive setup wizard, or configure direct
 --layout compact           # standard, compact, minimal, percent-first
 --wrap auto                # off (default, truncate) or auto (wrap to 2 lines at | when narrow)
 
+# Two-line layout (config.json) — deliberate split, unlike --wrap's overflow handling.
+#   "line2_widgets": ["model", "effort", "branch"]   push these to row 2
+#   "line1_widgets": ["session", "weekly"]           allowlist row 1, rest flows to row 2
+# line1_widgets wins if both are set.
+
 # Currency (auto-converts USD via live exchange rate)
 --currency £               # $, £, €, ¥, C$, A$, ₹, kr, and 20+ more
-
-# Peak hours (local time, weekdays only — Sat/Sun always off-peak per Anthropic policy)
---peak-hours 13:00-19:00   # Set your peak window
---peak-hours off           # Disable peak indicator
-# Set "display": "minimal" in config for short format (⚡ Peak 2h)
-# Set "weekdays_only": false in config to show the window every day
 
 # Clock
 --clock-format 12h         # 12h or 24h
@@ -148,10 +151,17 @@ Use `/pulse` in Claude Code for an interactive setup wizard, or configure direct
 --show burn_rate           # Show usage velocity (↑3%/hr)
 --show git_drift           # Show commits ahead/behind
 --show cumulative_cost     # Show total API-equivalent cost across all sessions
+--show weekly_cost         # Show rolling 7-day API-equivalent cost
+--show cache               # Show % of input served from cache (cost signal)
+--show pr                  # Show clickable PR badge + review state
+--show thinking            # Show whether extended thinking is on
 --show files_changed       # Show modified file count
 --show last_tool           # Show last tool Claude used
 --hide cost                # Hide cost ticker
 --hide heartbeat           # Hide tool counter
+--hide fable               # Hide the Fable weekly cap bar
+--hide fast_mode           # Hide the ⚡fast badge
+--hide agent               # Hide the active subagent name
 
 # Focus timer
 --focus start 25        # Start a 25-minute focus timer
@@ -216,7 +226,7 @@ Set with `--animate <mode>`. Animation moves on each status line refresh (intera
 
 ## Requirements
 
-- **Python 3.6+** (no pip installs needed)
+- **Python 3.8+** (no pip installs needed)
 - **Claude Code** with a Pro or Max subscription
 - No API key required — uses Claude Code's existing credentials
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ A single-file Python status bar for Claude Code that shows everything you need a
 </p>
 
 ```
-Session ━━━───────── 27% 2h 53m | Weekly ━━━━━━━━━─── 73% R:Fri 3pm | Fable ━━───────── 18% | Context ━━━━──────── 35% | $38.75 | +142 -37 | Opus 5 | xh | ⚡fast | [\] 320 tools 51m | main
+Session ━━━───────── 27% 2h 53m | Weekly ━━━━━━━━━─── 73% R:Fri 3pm | Fable ━━───────── 18% | Context ━━━━──────── 35% | $38.75 | +142 -37 | Opus 5 | Effort: XHigh | ⚡fast | [\] 320 tools 51m | main
 ```
 
 ## What's new in 3.2.0
@@ -57,7 +57,7 @@ Session ━━━───────── 27% 2h 53m | Weekly ━━━━━
 - **Corrupt state can't blank the bar** — a truncated or hand-edited cache/settings file used to raise on the hot path. Every state read now degrades to a cache miss instead, and one malformed rate-limit field no longer discards the windows after it.
 - **Peak hours removed.**
 
-Python floor is **3.8** — 3.1.0 advertised 3.6+ but did not parse below 3.12. Test suite: 21 → 120.
+Python floor is **3.8** — 3.1.0 advertised 3.6+ but did not parse below 3.12. Test suite: 21 → 133.
 
 ## Features
 
@@ -67,7 +67,7 @@ Python floor is **3.8** — 3.1.0 advertised 3.6+ but did not parse below 3.12. 
 | **Context window** | Live context usage percentage with pressure warnings at 70%/90% |
 | **Cost tracking** | Real-time session cost in your local currency (USD, GBP, EUR, + 25 more) with live exchange rates |
 | **Per-model weekly caps** | Separate bars for Opus, Sonnet and **Fable** weekly budgets, read from the model-scoped limits the API reports. Shown only when your plan actually reports them |
-| **Effort & fast mode** | Reasoning effort (`lo`/`med`/`hi`/`xh`/`max`, colour-escalating) and a **⚡fast** badge when Opus fast mode is active |
+| **Effort & fast mode** | Reasoning effort, written as `Effort: Medium` by default and colour-escalating with the level (`--effort-format full`/`short` for `Medium`/`med`), plus a **⚡fast** badge while Opus fast mode is on |
 | **Subagent & PR** | Active subagent name, plus an opt-in clickable PR badge with review state (OSC 8 hyperlink) |
 | **Cache efficiency** | Opt-in indicator for the share of input served from cache — the clearest cost signal on stdin |
 | **Two-line layout** | Split widgets across two rows with `line1_widgets` / `line2_widgets` |
@@ -152,6 +152,9 @@ Use `/pulse` in Claude Code for an interactive setup wizard, or configure direct
 
 # Currency (auto-converts USD via live exchange rate)
 --currency £               # $, £, €, ¥, C$, A$, ₹, kr, and 20+ more
+
+# Effort display (how the reasoning-effort level is written)
+--effort-format labeled    # labeled (default) 'Effort: Medium' · full 'Medium' · short 'med'
 
 # Clock
 --clock-format 12h         # 12h or 24h

--- a/README.md
+++ b/README.md
@@ -181,7 +181,8 @@ Use `/pulse` in Claude Code for an interactive setup wizard, or configure direct
 ┌───────────────────────────────────────────────┐
 │  Claude Code                                  │
 │  Pipes JSON via stdin on every status refresh │
-│  (model, context %, cost, rate_limits)        │
+│  (model, context, cost, rate_limits, effort,  │
+│   fast_mode, agent, pr, version)              │
 ├───────────────────────────────────────────────┤
 │  claude_status.py                             │
 │  Reads stdin → builds ANSI status line        │
@@ -192,15 +193,17 @@ Use `/pulse` in Claude Code for an interactive setup wizard, or configure direct
 │  on every tool call                           │
 ├───────────────────────────────────────────────┤
 │  Cache Layer                                  │
-│  Exchange rates (24h) · cumulative cost (5m)  │
-│  hook state (5m)                              │
-│  Animation state · usage history              │
+│  Exchange rates (24h) · update checks (1h)    │
+│  cumulative + weekly cost (5m) · hook (5m)    │
+│  429 backoff · animation state · history      │
 └───────────────────────────────────────────────┘
 ```
 
 **Data flow:** Claude Code sends session JSON via stdin → claude-pulse reads rate limits directly (no API) → renders colourised ANSI status line → Claude Code displays it.
 
-**Rate limits from stdin (v2.1.80+):** Claude Code now includes `rate_limits.five_hour` and `rate_limits.seven_day` in the stdin JSON, so claude-pulse no longer needs to call the Anthropic OAuth API. This eliminates rate limiting issues entirely.
+**Rate limits from stdin (v2.1.80+):** Claude Code sends `rate_limits` on stdin — the 5-hour and 7-day windows plus the model-scoped weekly caps (`seven_day_opus`, `seven_day_sonnet`, `seven_day_fable`). claude-pulse reads all of them straight from stdin, so no OAuth call is needed for the bars. The API is only consulted for extra/bonus credits, which stdin doesn't carry, and a 429 there now backs off exponentially instead of retrying on every repaint.
+
+**Refresh cadence:** Claude Code repaints on its own events (prompt, tool use), which covers anything derived from stdin. Content that moves with the clock — animation frames, the focus countdown, the heartbeat's elapsed time — also needs a timer, so `--install` sets `statusLine.refreshInterval` (2s when animating, 15s for time-based widgets, omitted entirely for a static bar). It is re-synced automatically whenever you change a setting.
 
 **PostToolUse hook:** When installed, the hook fires on every tool call (Read, Edit, Bash, etc.), updating the heartbeat counter and git branch. The status line refreshes on each tool call, making the spinner animate during active work.
 
@@ -222,12 +225,12 @@ Use `/pulse` in Claude Code for an interactive setup wizard, or configure direct
 | `glow` | Per-character gradient that shifts across the bar each frame |
 | `shift` | Bright highlight slides across the bar |
 
-Set with `--animate <mode>`. Animation moves on each status line refresh (interaction or tool call).
+Set with `--animate <mode>`. Animation advances on every repaint — Claude Code's own events plus the 2-second `refreshInterval` that `--install` configures while animation is on, so the bar keeps moving even while the session is idle.
 
 ## Requirements
 
 - **Python 3.8+** (no pip installs needed)
-- **Claude Code** with a Pro or Max subscription
+- **Claude Code** v2.1.80+ with a Pro or Max subscription (Fable reporting needs v2.1.170+)
 - No API key required — uses Claude Code's existing credentials
 
 ## Security
@@ -236,6 +239,7 @@ Set with `--animate <mode>`. Animation moves on each status line refresh (intera
 - OAuth tokens only used as fallback for extra credits/per-model caps, sent only to `api.anthropic.com` (hardcoded allowlist)
 - All file writes use atomic operations with 0o600 permissions
 - ANSI escape injection prevention on all external data
+- Hyperlink targets (PR badge) restricted to `http(s)` and rejected if they contain control characters, so nothing can break out of the OSC 8 escape
 - No `shell=True` in any subprocess call
 - Exchange rate API (frankfurter.app) — no auth, read-only, cached 24h
 
@@ -244,7 +248,9 @@ Set with `--animate <mode>`. Animation moves on each status line refresh (intera
 | Issue | Fix |
 |---|---|
 | No status line visible | Run `--install` then restart Claude Code |
-| "Rate limited" message | Update to v3.0.0+ — reads from stdin, no API calls needed |
+| "Rate limited" message | v3.0.0+ reads limits from stdin, so the bars keep working. v3.2.0+ also backs off exponentially before retrying the API |
+| Animation/timer frozen when idle | Re-run `--install` on v3.2.0+. Earlier versions wrote a `refresh` key that Claude Code ignores; the real setting is `refreshInterval` |
+| Opus/Sonnet/Fable bar missing | Those bars render only when your plan reports that cap. Claude Pro returns `null` for the model-scoped windows |
 | Heartbeat not showing | Run `--install-hooks` then restart Claude Code. Shows after first tool call |
 | Heartbeat appears/disappears | Normal — shows when hook state is fresh (within 5 min of last tool call) |
 | Settings error after hook install | Run `/doctor` — hooks need nested format: `{matcher, hooks: [{type, command}]}` |

--- a/README.md
+++ b/README.md
@@ -45,6 +45,18 @@ A single-file Python status bar for Claude Code that shows everything you need a
 Session ━━━───────── 27% 2h 53m | Weekly ━━━━━━━━━─── 73% R:Fri 3pm | Fable ━━───────── 18% | Context ━━━━──────── 35% | $38.75 | +142 -37 | Opus 5 | xh | ⚡fast | [\] 320 tools 51m | main
 ```
 
+## What's new in 3.2.0
+
+- **Fable weekly cap** — read from the model-scoped `limits` the API reports, so new models are picked up without a code change.
+- **Claude 5-era stdin fields** — reasoning effort, `⚡fast` mode, thinking state, active subagent, PR badge, and cache-hit ratio.
+- **Fixed: the refresh timer never worked.** Every version up to 3.1.0 wrote a `refresh` key that Claude Code does not have, so it was silently ignored — animations, the heartbeat and the focus countdown froze whenever the session went idle. The real setting is `refreshInterval`, and it is now set only when something time-based is on screen.
+- **~40% faster repaints** (204ms → 118ms): `claude --version` and `git rev-parse` were both running on *every* repaint just to validate hourly caches.
+- **Per-model bars no longer invent data** — Claude Pro reports `null` for the model-scoped windows, and 3.1.0 drew a hardcoded `Sonnet 0%` bar in that case.
+- **Two-line layout**, rolling **7-day cost** widget, `CLAUDE_CONFIG_DIR` support, exponential backoff on 429, and an update check that no longer nags forks forever.
+- **Peak hours removed.**
+
+Python floor is **3.8** — 3.1.0 advertised 3.6+ but did not parse below 3.12.
+
 ## Features
 
 | Feature | Description |

--- a/README.md
+++ b/README.md
@@ -52,10 +52,12 @@ Session ━━━───────── 27% 2h 53m | Weekly ━━━━━
 - **Fixed: the refresh timer never worked.** Every version up to 3.1.0 wrote a `refresh` key that Claude Code does not have, so it was silently ignored — animations, the heartbeat and the focus countdown froze whenever the session went idle. The real setting is `refreshInterval`, and it is now set only when something time-based is on screen.
 - **~40% faster repaints** (204ms → 118ms): `claude --version` and `git rev-parse` were both running on *every* repaint just to validate hourly caches.
 - **Per-model bars no longer invent data** — Claude Pro reports `null` for the model-scoped windows, and 3.1.0 drew a hardcoded `Sonnet 0%` bar in that case.
+- **Zero API calls, for real** — the per-model caps arrive on stdin, but 3.1.0 discarded them and re-fetched over OAuth. That call is gone.
 - **Two-line layout**, rolling **7-day cost** widget, `CLAUDE_CONFIG_DIR` support, exponential backoff on 429, and an update check that no longer nags forks forever.
+- **Corrupt state can't blank the bar** — a truncated or hand-edited cache/settings file used to raise on the hot path. Every state read now degrades to a cache miss instead, and one malformed rate-limit field no longer discards the windows after it.
 - **Peak hours removed.**
 
-Python floor is **3.8** — 3.1.0 advertised 3.6+ but did not parse below 3.12.
+Python floor is **3.8** — 3.1.0 advertised 3.6+ but did not parse below 3.12. Test suite: 21 → 120.
 
 ## Features
 

--- a/claude_status.py
+++ b/claude_status.py
@@ -3256,6 +3256,29 @@ def _parse_stdin_context(raw_stdin):
 
     result = {}
 
+    # Is this a full repaint payload rather than a fragment? Claude Code always
+    # sends the session identity fields on a real status refresh, so their
+    # presence means an omitted session-state field genuinely means "off", not
+    # "unknown". Without this, a field that is simply dropped when inactive
+    # (rather than sent as false) could never clear the badge it set, because
+    # the persistence layer treats absent as unchanged.
+    try:
+        _payload = data.get("data", data)
+        _full = isinstance(_payload, dict) and any(
+            k in _payload for k in ("session_id", "model", "workspace", "transcript_path")
+        )
+    except (AttributeError, TypeError):
+        _payload, _full = {}, False
+    if _full:
+        # Defaults for session state; each block below overwrites when present.
+        result["fast_mode"] = False
+        result["effort"] = None
+        result["thinking"] = None
+        result["agent_name"] = None
+        result["pr_number"] = None
+        result["pr_url"] = None
+        result["pr_review_state"] = None
+
     # Model name
     try:
         model = data.get("data", data).get("model", {})
@@ -3319,18 +3342,28 @@ def _parse_stdin_context(raw_stdin):
     # — so the effort widget only ever rendered for users who happened to set
     # that variable by hand. stdin is the real source; the env var is kept
     # below as a fallback for anyone relying on the old behaviour.
+    # These are *session state*, not accumulating facts: each can be switched
+    # off again mid-session. Record the value whenever the field is present —
+    # including the off value — because the persistence layer below treats an
+    # absent key as "unchanged". Recording only the on value meant a badge
+    # could never be cleared: toggle fast mode on once and the ⚡fast marker
+    # stuck forever, even as Claude Code reported fast_mode: false.
     try:
         payload = data.get("data", data)
-        effort = payload.get("effort")
-        if isinstance(effort, dict):
-            level = _sanitize(str(effort.get("level") or ""))
-            if level and level != "unset":
-                result["effort"] = level
-        if payload.get("fast_mode") is True:
-            result["fast_mode"] = True
-        thinking = payload.get("thinking")
-        if isinstance(thinking, dict) and thinking.get("enabled") is not None:
-            result["thinking"] = bool(thinking.get("enabled"))
+        if "effort" in payload:
+            effort = payload.get("effort")
+            level = ""
+            if isinstance(effort, dict):
+                level = _sanitize(str(effort.get("level") or ""))
+            result["effort"] = level if level and level != "unset" else None
+        if "fast_mode" in payload:
+            result["fast_mode"] = payload.get("fast_mode") is True
+        if "thinking" in payload:
+            thinking = payload.get("thinking")
+            if isinstance(thinking, dict) and thinking.get("enabled") is not None:
+                result["thinking"] = bool(thinking.get("enabled"))
+            else:
+                result["thinking"] = None
     except (AttributeError, KeyError, TypeError, ValueError):
         pass
 
@@ -3344,9 +3377,16 @@ def _parse_stdin_context(raw_stdin):
     except (AttributeError, KeyError, TypeError):
         pass
 
-    # Pull request context (number / url / review_state).
+    # Pull request context (number / url / review_state). Also session state:
+    # switching off a PR branch must clear the badge, so an explicitly absent
+    # or empty `pr` clears rather than leaving the previous one pinned.
     try:
-        pr = data.get("data", data).get("pr")
+        payload = data.get("data", data)
+        pr = payload.get("pr")
+        if "pr" in payload and not (isinstance(pr, dict) and pr.get("number") is not None):
+            result["pr_number"] = None
+            result["pr_url"] = None
+            result["pr_review_state"] = None
         if isinstance(pr, dict) and pr.get("number") is not None:
             result["pr_number"] = int(pr["number"])
             url = _sanitize(pr.get("url", ""))

--- a/claude_status.py
+++ b/claude_status.py
@@ -1,11 +1,12 @@
 #!/usr/bin/env python3
 """Claude Code status line — reads usage data from Claude Code's stdin and displays real-time bars."""
 
-VERSION = "3.1.0"
+VERSION = "3.2.0"
 
 import json
 import math
 import os
+import random
 import re
 import shutil
 import signal
@@ -112,48 +113,89 @@ PLAN_NAMES = {
     "default_claude_max_20x": "Max 20x",
 }
 
+# Model id → short display name. Longest-prefix wins (see _model_short_name),
+# so "claude-opus-4-8" beats the bare "claude-opus-4" entry.
 MODEL_SHORT_NAMES = {
-    "claude-opus-4": "Opus",
-    "claude-sonnet-4": "Sonnet",
-    "claude-haiku-4": "Haiku",
+    "claude-fable-5": "Fable",
+    "claude-mythos-5": "Mythos",
+    "claude-opus-5": "Opus",
+    "claude-opus-4-8": "Opus",
+    "claude-opus-4-7": "Opus",
     "claude-opus-4-6": "Opus",
+    "claude-opus-4-5": "Opus",
+    "claude-opus-4": "Opus",
+    "claude-sonnet-5": "Sonnet",
+    "claude-sonnet-4-6": "Sonnet",
     "claude-sonnet-4-5": "Sonnet",
+    "claude-sonnet-4": "Sonnet",
     "claude-haiku-4-5": "Haiku",
+    "claude-haiku-4": "Haiku",
     "claude-3-5-sonnet": "Sonnet",
     "claude-3-5-haiku": "Haiku",
     "claude-3-opus": "Opus",
 }
 
-# Context window sizes by model short name (used to derive token counts from %)
+# Context window sizes by model display name, as it arrives on stdin
+# ("Opus 4.6", "Sonnet 5", ...) with a bare-family fallback. Only consulted
+# when stdin omits context_window.context_window_size; when that field is
+# present we always trust it over this table.
+#
+# The Claude 5 family and Opus/Sonnet 4.6+ are 1M-context; Haiku 4.5 and the
+# Claude 3.x models remain 200K.
 MODEL_CONTEXT_WINDOWS = {
-    "Opus": 200_000,
-    "Opus 4.6": 200_000,
-    "Sonnet": 200_000,
-    "Sonnet 4": 200_000,
+    "Fable": 1_000_000,
+    "Fable 5": 1_000_000,
+    "Mythos": 1_000_000,
+    "Mythos 5": 1_000_000,
+    "Opus": 1_000_000,
+    "Opus 5": 1_000_000,
+    "Opus 4.8": 1_000_000,
+    "Opus 4.7": 1_000_000,
+    "Opus 4.6": 1_000_000,
+    "Opus 4.5": 200_000,
+    "Sonnet": 1_000_000,
+    "Sonnet 5": 1_000_000,
+    "Sonnet 4.6": 1_000_000,
     "Sonnet 4.5": 200_000,
+    "Sonnet 4": 200_000,
     "Haiku": 200_000,
     "Haiku 4.5": 200_000,
 }
 DEFAULT_CONTEXT_WINDOW = 200_000
 
-# API pricing per million tokens (USD) — updated 2025
-# https://docs.anthropic.com/en/docs/about-claude/pricing
+# API pricing per million tokens (USD).
+# https://platform.claude.com/docs/en/pricing
+# Cache read is 0.1x input; 5-minute cache write is 1.25x input.
 API_PRICING = {
-    "claude-opus-4-6": {"input": 15.0, "output": 75.0, "cache_read": 1.5, "cache_write": 18.75},
+    "claude-fable-5": {"input": 10.0, "output": 50.0, "cache_read": 1.0, "cache_write": 12.5},
+    "claude-mythos-5": {"input": 10.0, "output": 50.0, "cache_read": 1.0, "cache_write": 12.5},
+    "claude-opus-5": {"input": 5.0, "output": 25.0, "cache_read": 0.50, "cache_write": 6.25},
+    "claude-opus-4-8": {"input": 5.0, "output": 25.0, "cache_read": 0.50, "cache_write": 6.25},
+    "claude-opus-4-7": {"input": 5.0, "output": 25.0, "cache_read": 0.50, "cache_write": 6.25},
+    "claude-opus-4-6": {"input": 5.0, "output": 25.0, "cache_read": 0.50, "cache_write": 6.25},
+    "claude-opus-4-5": {"input": 5.0, "output": 25.0, "cache_read": 0.50, "cache_write": 6.25},
     "claude-opus-4": {"input": 15.0, "output": 75.0, "cache_read": 1.5, "cache_write": 18.75},
+    "claude-sonnet-5": {"input": 3.0, "output": 15.0, "cache_read": 0.30, "cache_write": 3.75},
     "claude-sonnet-4-6": {"input": 3.0, "output": 15.0, "cache_read": 0.30, "cache_write": 3.75},
     "claude-sonnet-4-5": {"input": 3.0, "output": 15.0, "cache_read": 0.30, "cache_write": 3.75},
     "claude-sonnet-4": {"input": 3.0, "output": 15.0, "cache_read": 0.30, "cache_write": 3.75},
-    "claude-haiku-4-5-20251001": {"input": 0.80, "output": 4.0, "cache_read": 0.08, "cache_write": 1.0},
-    "claude-haiku-4-5": {"input": 0.80, "output": 4.0, "cache_read": 0.08, "cache_write": 1.0},
+    "claude-haiku-4-5-20251001": {"input": 1.0, "output": 5.0, "cache_read": 0.10, "cache_write": 1.25},
+    "claude-haiku-4-5": {"input": 1.0, "output": 5.0, "cache_read": 0.10, "cache_write": 1.25},
     "claude-3-5-sonnet": {"input": 3.0, "output": 15.0, "cache_read": 0.30, "cache_write": 3.75},
     "claude-3-5-haiku": {"input": 0.80, "output": 4.0, "cache_read": 0.08, "cache_write": 1.0},
     "claude-3-opus": {"input": 15.0, "output": 75.0, "cache_read": 1.5, "cache_write": 18.75},
 }
 # Display names for pricing table
 API_PRICING_DISPLAY = {
+    "claude-fable-5": "Fable 5",
+    "claude-mythos-5": "Mythos 5",
+    "claude-opus-5": "Opus 5",
+    "claude-opus-4-8": "Opus 4.8",
+    "claude-opus-4-7": "Opus 4.7",
     "claude-opus-4-6": "Opus 4.6",
+    "claude-opus-4-5": "Opus 4.5",
     "claude-opus-4": "Opus 4",
+    "claude-sonnet-5": "Sonnet 5",
     "claude-sonnet-4-6": "Sonnet 4.6",
     "claude-sonnet-4-5": "Sonnet 4.5",
     "claude-sonnet-4": "Sonnet 4",
@@ -163,6 +205,24 @@ API_PRICING_DISPLAY = {
     "claude-3-5-haiku": "Haiku 3.5",
     "claude-3-opus": "Opus 3",
 }
+
+
+def _model_short_name(model_id):
+    """Map a model id to its short family name, longest prefix wins.
+
+    ``MODEL_SHORT_NAMES`` holds both bare-family keys ("claude-opus-4") and
+    versioned ones ("claude-opus-4-8"). A plain dict lookup misses dated
+    variants like ``claude-haiku-4-5-20251001``, and a naive prefix scan would
+    let "claude-opus-4" shadow "claude-opus-4-8", so match on the longest key
+    that the id starts with.
+    """
+    if not model_id:
+        return None
+    best = None
+    for key, short in MODEL_SHORT_NAMES.items():
+        if model_id.startswith(key) and (best is None or len(key) > len(best[0])):
+            best = (key, short)
+    return best[1] if best else None
 
 # ---------------------------------------------------------------------------
 # Hook infrastructure constants
@@ -376,11 +436,36 @@ THEME_TEXT_DEFAULTS = {
 # Widget priorities — lower number = rendered first (leftmost).
 # Users can override via config["widget_priority"] = {"session": 1, "weekly": 2, ...}
 WIDGET_PRIORITY = {
-    "session": 10, "weekly": 20, "opus": 30, "sonnet": 40, "extra": 50,
-    "context": 60, "cost": 70, "cumulative_cost": 72, "lines": 75, "peak": 80, "plan": 90,
-    "streak": 100, "model": 110, "effort": 120, "worktree": 130,
+    "session": 10, "weekly": 20, "opus": 30, "sonnet": 40, "fable": 45, "extra": 50,
+    "context": 60, "cache": 65, "cost": 70, "cumulative_cost": 72,
+    "weekly_cost": 73, "lines": 75, "plan": 90,
+    "streak": 100, "model": 110, "effort": 120, "fast_mode": 122,
+    "thinking": 124, "agent": 126, "worktree": 130,
     "heartbeat": 140, "activity": 150, "last_tool": 160, "branch": 170,
+    "pr": 175,
     "sessions": 180, "pomodoro": 190, "git_drift": 200, "files_changed": 210,
+}
+
+# Reasoning-effort display. Claude Code reports low|medium|high|xhigh|max.
+EFFORT_SHORT = {
+    "low": "lo", "medium": "med", "high": "hi", "xhigh": "xh", "max": "max",
+}
+
+# Higher effort burns limits faster, so escalate the colour with it.
+EFFORT_COLOURS = {
+    "low": DIM, "medium": "", "high": "", "xhigh": YELLOW, "max": BRIGHT_RED,
+}
+
+# Pull-request review states, as reported on stdin.
+PR_STATE_GLYPHS = {
+    "approved": "✓",       # ✓
+    "changes_requested": "✗",  # ✗
+    "pending": "•",        # •
+}
+PR_STATE_COLOURS = {
+    "approved": GREEN,
+    "changes_requested": RED,
+    "pending": YELLOW,
 }
 
 DEFAULT_SHOW = {
@@ -401,10 +486,14 @@ DEFAULT_SHOW = {
     # Per-model caps (show when available)
     "opus": True,
     "sonnet": True,
+    "fable": True,
     # Opt-in features
     "plan": False,
     "extra": False,
     "effort": True,
+    "fast_mode": True,
+    "thinking": False,
+    "agent": True,
     "worktree": True,
     "pomodoro": True,
     "context_warning": True,
@@ -412,6 +501,9 @@ DEFAULT_SHOW = {
     "lines": True,
     # Hidden by default — opt-in with --show
     "cumulative_cost": False,
+    "weekly_cost": False,
+    "cache": False,
+    "pr": False,
     "burn_rate": False,
     "sessions": False,
     "last_tool": False,
@@ -776,6 +868,25 @@ def _atomic_json_write(filepath, data, indent=2):
 # Config
 # ---------------------------------------------------------------------------
 
+def _claude_config_dir():
+    """Return Claude Code's active config dir, honouring ``CLAUDE_CONFIG_DIR``.
+
+    Claude Code reads settings, commands and credentials from
+    ``$CLAUDE_CONFIG_DIR`` when it is set, falling back to ``~/.claude``.
+    ``install.sh`` / ``install.ps1`` already respect it; before this helper
+    ``claude_status.py`` always wrote to ``~/.claude``, so a multi-profile user
+    got the status line registered in one dir and the ``/pulse`` command in
+    another, and the meter silently never appeared.
+
+    An empty or whitespace-only value is treated as unset rather than as the
+    process working directory, which is what ``Path("")`` would resolve to.
+    """
+    raw = os.environ.get("CLAUDE_CONFIG_DIR", "")
+    if raw and raw.strip():
+        return Path(raw.strip()).expanduser()
+    return Path.home() / ".claude"
+
+
 def get_config_path():
     """Return path to user config — stored under XDG_CONFIG_HOME, outside the repo."""
     if sys.platform == "win32":
@@ -874,6 +985,10 @@ def load_config():
     # Clean up removed settings
     data.pop("rainbow_bars", None)
     data.pop("rainbow_mode", None)
+    # v3.2.0 removed the peak-hours widget. Drop the settings an older version
+    # may have written so they don't linger in --config output forever. The
+    # matching show flag is dropped below, once `show` has been read.
+    data.pop("peak_hours", None)
 
     # Apply defaults
     data.setdefault("cache_ttl_seconds", DEFAULT_CACHE_TTL)
@@ -894,13 +1009,8 @@ def load_config():
     data.setdefault("extra_display", "auto")
     if "currency" not in data:
         data["currency"] = _detect_default_currency()
-    peak = data.get("peak_hours", {})
-    peak.setdefault("enabled", True)
-    peak.setdefault("start", "13:00")
-    peak.setdefault("end", "19:00")
-    peak.setdefault("weekdays_only", True)
-    data["peak_hours"] = peak
     show = data.get("show", {})
+    show.pop("peak", None)  # v3.2.0 — widget removed
     for key, default in DEFAULT_SHOW.items():
         show.setdefault(key, default)
     data["show"] = show
@@ -912,6 +1022,14 @@ def save_config(config):
     # Only save user-facing keys, not internal ones
     save_data = {k: v for k, v in config.items() if not k.startswith("_")}
     _atomic_json_write(config_path, save_data)
+    # Toggling animation or a time-based widget changes whether the status line
+    # needs a repaint timer. Re-syncing here rather than at each of the ~20 CLI
+    # call sites means a new setting can never forget to do it. Never raises:
+    # a settings.json we can't touch must not fail an otherwise-good config save.
+    try:
+        sync_status_line_refresh(config)
+    except Exception:
+        pass
 
 
 def _cleanup_hooks():
@@ -924,7 +1042,7 @@ def _cleanup_hooks():
     marker = state_dir / "hooks_cleaned"
     if marker.exists():
         return
-    settings_path = Path.home() / ".claude" / "settings.json"
+    settings_path = _claude_config_dir() / "settings.json"
     try:
         with open(settings_path, "r", encoding="utf-8") as f:
             settings = json.load(f)
@@ -1076,7 +1194,7 @@ def hook_refresh(tool_name_arg):
 
 def install_hooks():
     """Install a PostToolUse hook into ~/.claude/settings.json."""
-    settings_path = Path.home() / ".claude" / "settings.json"
+    settings_path = _claude_config_dir() / "settings.json"
     script_path = _win_portable_path(Path(__file__).resolve())
     python_cmd = _get_python_cmd()
     settings = {}
@@ -1217,6 +1335,63 @@ def get_remote_commit():
         return None
 
 
+def _git(*args, timeout=5):
+    """Run git in the install dir, returning stripped stdout or None."""
+    repo_dir = Path(__file__).resolve().parent
+    try:
+        result = subprocess.run(
+            [_GIT_PATH, *args],
+            capture_output=True, text=True, timeout=timeout,
+            cwd=str(repo_dir),
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except Exception:
+        pass
+    return None
+
+
+def _tracks_upstream():
+    """True when this checkout's origin is the upstream claude-pulse repo.
+
+    A fork's origin points somewhere else, and its own commits are never on
+    upstream's main, so the plain ``local != remote`` comparison flagged an
+    update forever. Returns None when origin can't be read at all.
+    """
+    url = _git("remote", "get-url", "origin", timeout=3)
+    if url is None:
+        return None
+    owner_repo = GITHUB_REPO.lower()
+    normalised = url.lower().rstrip("/")
+    if normalised.endswith(".git"):
+        normalised = normalised[:-4]
+    # Matches both git@github.com:owner/repo and https://github.com/owner/repo
+    return normalised.endswith(owner_repo)
+
+
+def _remote_is_ancestor(remote):
+    """True when *remote* is already contained in local history (we're ahead).
+
+    Returns None when the commit isn't present locally, so ancestry can't be
+    decided without fetching — which the status line must never do.
+    """
+    if _git("cat-file", "-e", f"{remote}^{{commit}}", timeout=3) is None:
+        return None
+    repo_dir = Path(__file__).resolve().parent
+    try:
+        result = subprocess.run(
+            [_GIT_PATH, "merge-base", "--is-ancestor", remote, "HEAD"],
+            capture_output=True, text=True, timeout=5, cwd=str(repo_dir),
+        )
+    except Exception:
+        return None
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    return None  # any other status means git could not answer
+
+
 def check_for_update():
     """Check if a newer version is available on GitHub. Returns True/False/None.
 
@@ -1225,27 +1400,59 @@ def check_for_update():
     state_dir = get_state_dir()
     update_cache = state_dir / "update_check.json"
 
-    # Get local commit first so we can validate cache
+    # `git rev-parse HEAD` costs ~20ms, and it was previously run on every
+    # repaint purely to validate an hourly cache. Instead, stamp the cache with
+    # the script's mtime: if the file hasn't changed since the cache was
+    # written, the checkout hasn't moved either, so the cached verdict stands
+    # and git never runs. A pull rewrites claude_status.py and invalidates it.
+    try:
+        script_mtime = Path(__file__).resolve().stat().st_mtime
+    except OSError:
+        script_mtime = None
+
+    cached = None
+    try:
+        with open(update_cache, "r", encoding="utf-8") as f:
+            cached = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        cached = None
+
+    if cached and time.time() - cached.get("timestamp", 0) < UPDATE_CHECK_TTL:
+        if script_mtime is not None and cached.get("script_mtime") == script_mtime:
+            return cached.get("update_available", False)
+
+    # Cache is stale or unverifiable — now it's worth asking git.
     local = get_local_commit()
     if not local:
         return None  # not a git install, skip silently
 
-    # Read cached result — skip if local version changed (e.g. after update)
-    try:
-        with open(update_cache, "r", encoding="utf-8") as f:
-            cached = json.load(f)
-        if (time.time() - cached.get("timestamp", 0) < UPDATE_CHECK_TTL
-                and cached.get("local") == local[:8]):
-            return cached.get("update_available", False)
-    except (FileNotFoundError, json.JSONDecodeError, KeyError):
-        pass
+    if (cached
+            and time.time() - cached.get("timestamp", 0) < UPDATE_CHECK_TTL
+            and cached.get("local") == local[:8]):
+        return cached.get("update_available", False)
+
+    # A fork's own commits are never on upstream main, so a bare inequality
+    # would nag forever. Only ever prompt a checkout that actually tracks
+    # upstream (issue: forks false-positive on the update indicator).
+    if _tracks_upstream() is False:
+        return None
 
     # Perform the check
     remote = get_remote_commit()
     if not remote:
         return None  # network error, skip silently
 
-    update_available = local != remote
+    if local == remote:
+        update_available = False
+    else:
+        ancestor = _remote_is_ancestor(remote)
+        if ancestor is None:
+            # Can't decide locally (commit not fetched) — fall back to the
+            # simple comparison, which is right for a plain tracking install.
+            update_available = True
+        else:
+            # We're only behind when upstream's tip is NOT already in our history.
+            update_available = not ancestor
 
     # Cache the result
     try:
@@ -1255,6 +1462,7 @@ def check_for_update():
                 "update_available": update_available,
                 "local": local[:8],
                 "remote": remote[:8],
+                "script_mtime": script_mtime,
             }, f)
     except OSError:
         pass
@@ -1276,29 +1484,36 @@ def append_update_indicator(line, config=None):
     return line
 
 
-def check_claude_code_update():
+def check_claude_code_update(local_version=None):
     """Check if a newer Claude Code version is available on npm. Returns True/False/None.
 
     Cached for 1 hour. Fully silent on any error — never blocks the status line.
-    """
-    if not _CLAUDE_PATH:
-        return None
 
+    *local_version* is the running version, which Claude Code reports on stdin.
+    Passing it matters for latency: resolving it by shelling out to
+    ``claude --version`` costs ~80ms, and because the version is needed to
+    validate the cache, that subprocess used to run on *every* repaint — by far
+    the most expensive thing the status line did. The subprocess remains as a
+    fallback for older Claude Code builds that don't send the field.
+    """
     state_dir = get_state_dir()
     update_cache = state_dir / "claude_code_update.json"
 
-    # Get installed version first so we can validate cache
-    try:
-        result = subprocess.run(
-            [_CLAUDE_PATH, "--version"],
-            capture_output=True, text=True, timeout=3,
-        )
-        if result.returncode != 0:
+    local_version = _sanitize(str(local_version or "")).strip()
+    if not local_version:
+        if not _CLAUDE_PATH:
             return None
-        # Parse "2.1.37 (Claude Code)" → "2.1.37"
-        local_version = result.stdout.strip().split()[0]
-    except Exception:
-        return None
+        try:
+            result = subprocess.run(
+                [_CLAUDE_PATH, "--version"],
+                capture_output=True, text=True, timeout=3,
+            )
+            if result.returncode != 0:
+                return None
+            # Parse "2.1.37 (Claude Code)" → "2.1.37"
+            local_version = result.stdout.strip().split()[0]
+        except Exception:
+            return None
 
     # Read cached result — skip if local version changed (e.g. after claude update)
     try:
@@ -1341,14 +1556,14 @@ def check_claude_code_update():
     return update_available
 
 
-def append_claude_update_indicator(line, config=None):
+def append_claude_update_indicator(line, config=None, stdin_ctx=None):
     """Append a visible Claude Code update indicator if a newer version is available."""
     try:
         if config:
             show = config.get("show", DEFAULT_SHOW)
             if not show.get("claude_update", True):
                 return line
-        if check_claude_code_update():
+        if check_claude_code_update((stdin_ctx or {}).get("cc_version")):
             return line + f" {BRIGHT_YELLOW}\u2191 Claude Update{RESET}"
     except Exception:
         pass  # never break the status line for an update check
@@ -1534,6 +1749,16 @@ def read_cache(cache_path, ttl):
     try:
         with open(cache_path, "r", encoding="utf-8") as f:
             cached = json.load(f)
+        # An active 429 backoff wins over the normal TTL: keep serving what we
+        # have until the backoff expires. Without this, a rate-limited session
+        # that still had usable cached usage re-hit the API on every refresh —
+        # exactly the retry storm the backoff exists to prevent.
+        try:
+            blocked_until = float(cached.get("rate_limited_until") or 0)
+        except (TypeError, ValueError):
+            blocked_until = 0
+        if blocked_until and time.time() < blocked_until:
+            return cached
         # Error-only entries expire faster, except rate limit errors which back off longer
         if "usage" in cached:
             effective_ttl = ttl
@@ -1565,19 +1790,58 @@ def _read_stale_cache(cache_path):
     return None
 
 
-_USAGE_CACHE_KEYS = {"five_hour", "seven_day", "seven_day_opus", "seven_day_sonnet", "extra_usage"}
+_USAGE_CACHE_KEYS = {
+    "five_hour", "seven_day", "seven_day_opus", "seven_day_sonnet",
+    "seven_day_fable", "extra_usage",
+}
 
-def write_cache(cache_path, line, usage=None, plan=None):
+def write_cache(cache_path, line, usage=None, plan=None,
+                rate_limited_until=None, rate_limit_fails=None):
+    """Persist the rendered line plus optional usage/plan and 429 backoff state.
+
+    ``rate_limited_until`` is an epoch after which it is worth calling the API
+    again; ``rate_limit_fails`` is the consecutive-429 count that produced it.
+    Both are omitted on a normal write, which is what clears the backoff once a
+    request succeeds.
+    """
     try:
         data = {"timestamp": time.time(), "line": line}
         if usage is not None:
             data["usage"] = {k: v for k, v in usage.items() if k in _USAGE_CACHE_KEYS}
         if plan is not None:
             data["plan"] = plan
+        if rate_limited_until:
+            data["rate_limited_until"] = rate_limited_until
+            data["rate_limited"] = True
+        if rate_limit_fails:
+            data["rate_limit_fails"] = rate_limit_fails
         with _secure_open_write(cache_path) as f:
             json.dump(data, f)
     except OSError:
         pass
+
+
+_RATE_LIMIT_BACKOFF_BASE = 60    # seconds for the first 429
+_RATE_LIMIT_BACKOFF_MAX = 900    # cap at 15 minutes
+_RATE_LIMIT_JITTER = 10          # spread concurrent sessions out
+
+
+def _rate_limit_backoff(fail_count):
+    """Return (seconds_to_wait, next_fail_count) for a 429.
+
+    Doubles per consecutive failure up to a cap, plus jitter so several Claude
+    Code windows that were rate-limited together don't all retry on the same
+    tick and re-trigger the limit.
+    """
+    try:
+        fails = max(0, int(fail_count or 0)) + 1
+    except (TypeError, ValueError):
+        fails = 1
+    # Cap the shift before computing the power: 2 ** a large fail count would
+    # build a huge int before min() ever saw it.
+    delay = _RATE_LIMIT_BACKOFF_BASE * (2 ** min(fails - 1, 8))
+    delay = min(delay, _RATE_LIMIT_BACKOFF_MAX)
+    return delay + random.uniform(0, _RATE_LIMIT_JITTER), fails
 
 
 # ---------------------------------------------------------------------------
@@ -1625,7 +1889,7 @@ def _authorized_request(url, token, headers=None, data=None, method=None, timeou
 def _read_credential_data():
     """Read raw credential data from file or macOS Keychain. Returns (dict, source)."""
     # 1. File-based (~/.claude/.credentials.json)
-    creds_path = Path.home() / ".claude" / ".credentials.json"
+    creds_path = _claude_config_dir() / ".credentials.json"
     try:
         with open(creds_path, "r", encoding="utf-8") as f:
             data = json.load(f)
@@ -1720,13 +1984,64 @@ def refresh_and_retry(plan):
     return token_data["access_token"], plan
 
 
+def _normalize_usage(usage):
+    """Fold model-scoped weekly caps out of ``limits[]`` into top-level keys.
+
+    Alongside the flat ``seven_day_opus`` / ``seven_day_sonnet`` fields, the
+    oauth/usage payload carries a ``limits`` list describing per-model weekly
+    budgets::
+
+        {"kind": "weekly_scoped", "percent": 82, "resets_at": "...",
+         "scope": {"model": {"display_name": "Fable"}}}
+
+    Mapping those to ``seven_day_<name>`` lets the renderer treat a Fable cap
+    exactly like the Opus and Sonnet ones, and picks up any future model
+    without another code change. A flat field that already carries a
+    utilization always wins — this only fills gaps.
+    """
+    if not isinstance(usage, dict):
+        return usage
+    limits = usage.get("limits")
+    if not isinstance(limits, list):
+        return usage
+    for entry in limits:
+        if not isinstance(entry, dict) or entry.get("kind") != "weekly_scoped":
+            continue
+        scope = entry.get("scope")
+        model = scope.get("model") if isinstance(scope, dict) else None
+        if not isinstance(model, dict):
+            continue
+        name = model.get("display_name") or model.get("id")
+        if not name:
+            continue
+        # "Fable" → seven_day_fable; "Sonnet 4.6" → seven_day_sonnet_4_6
+        key = "seven_day_" + re.sub(r"[^a-z0-9]+", "_", str(name).lower()).strip("_")
+        if not key.strip("_"):
+            continue
+        existing = usage.get(key)
+        if isinstance(existing, dict) and existing.get("utilization") is not None:
+            continue
+        pct = entry.get("percent")
+        if pct is None:
+            continue
+        try:
+            utilization = float(pct)
+        except (TypeError, ValueError):
+            continue
+        usage[key] = {
+            "utilization": utilization,
+            "resets_at": entry.get("resets_at"),
+        }
+    return usage
+
+
 def fetch_usage(token):
     with _authorized_request(
         "https://api.anthropic.com/api/oauth/usage",
         token,
         headers={"anthropic-beta": "oauth-2025-04-20", "Accept": "application/json"},
     ) as resp:
-        return json.loads(resp.read(1_000_000))  # 1 MB max
+        return _normalize_usage(json.loads(resp.read(1_000_000)))  # 1 MB max
 
 
 # ---------------------------------------------------------------------------
@@ -2398,89 +2713,6 @@ def _format_context_warning(ctx_pct, theme):
     return None, None
 
 
-PEAK_DISPLAYS = ("full", "minimal")
-DEFAULT_PEAK_DISPLAY = "full"
-
-
-def _fmt_peak_time(hhmm_str, clock="12h"):
-    """Format a HH:MM string as 12h (1pm) or 24h (13:00)."""
-    try:
-        h, m = int(hhmm_str.split(":")[0]), int(hhmm_str.split(":")[1])
-        if clock == "12h":
-            if h == 0:
-                return "12am"
-            elif h < 12:
-                return f"{h}am"
-            elif h == 12:
-                return "12pm"
-            else:
-                return f"{h - 12}pm"
-        return hhmm_str
-    except (ValueError, IndexError):
-        return hhmm_str
-
-
-def _check_peak_hours(config):
-    """Check peak hours status. Returns (is_peak, display_str).
-
-    Full mode:
-      In peak:      'In Peak ⚡ 2h left (1pm-7pm)'   RED — burning limits faster
-      Approaching:  'Peak ⚡ in 45m'                  YELLOW — heads up
-      Off-peak:     'Off-Peak ✓'                      GREEN — limits stretch further
-
-    Minimal mode:
-      In peak:      '⚡ Peak 2h'
-      Approaching:  '⚡ 45m'
-      Off-peak:     '✓ Off-Peak'
-
-    Per Anthropic's published policy, peak applies on weekdays only — Saturdays
-    and Sundays are always off-peak. Users can opt out by setting
-    peak_hours.weekdays_only = false in their config.
-    """
-    peak = config.get("peak_hours", {})
-    if not peak.get("enabled", True):
-        return False, ""
-    try:
-        start_str = peak.get("start", "13:00")
-        end_str = peak.get("end", "19:00")
-        clock = config.get("clock_format", "12h")
-        display_mode = peak.get("display", DEFAULT_PEAK_DISPLAY)
-        minimal = display_mode == "minimal"
-        weekdays_only = peak.get("weekdays_only", True)
-        sh, sm = int(start_str.split(":")[0]), int(start_str.split(":")[1])
-        eh, em = int(end_str.split(":")[0]), int(end_str.split(":")[1])
-        now = datetime.now()
-        # Mon=0..Fri=4 weekdays; Sat=5, Sun=6 weekends.
-        if weekdays_only and now.weekday() >= 5:
-            return False, "✓ Off-Peak" if minimal else "Off-Peak ✓"
-        now_mins = now.hour * 60 + now.minute
-        start_mins = sh * 60 + sm
-        end_mins = eh * 60 + em
-        start_display = _fmt_peak_time(start_str, clock)
-        end_display = _fmt_peak_time(end_str, clock)
-
-        if start_mins <= now_mins < end_mins:
-            left = end_mins - now_mins
-            left_str = f"{left // 60}h {left % 60}m" if left >= 60 else f"{left}m"
-            if minimal:
-                return True, f"\u26a1 Peak {left_str}"
-            return True, f"In Peak \u26a1 {left_str} left ({start_display}-{end_display})"
-
-        if now_mins < start_mins:
-            until = start_mins - now_mins
-            if until <= 120:
-                until_str = f"{until // 60}h {until % 60}m" if until >= 60 else f"{until}m"
-                if minimal:
-                    return False, f"\u26a1 {until_str}"
-                return False, f"Peak \u26a1 in {until_str}"
-
-        if minimal:
-            return False, "\u2713 Off-Peak"
-        return False, "Off-Peak \u2713"
-    except (ValueError, AttributeError):
-        return False, ""
-
-
 def _get_status_message(pct, velocity=None):
     """Return a (message, severity) tuple based on usage percentage and velocity.
 
@@ -2599,7 +2831,7 @@ def _calculate_streak(daily_dates, today):
         if d_ord == check_ord:
             current_streak += 1
             check_ord -= 1
-        elif d_ord == check_ord + 1 and current_streak == 0:
+        elif d_ord == check_ord - 1 and current_streak == 0:
             # Today not logged yet, start from yesterday
             current_streak = 1
             check_ord = d_ord - 1
@@ -2660,6 +2892,41 @@ def _get_streak_display(config, stats):
 _CUMULATIVE_COST_CACHE_TTL = 300  # 5 minutes
 _cumulative_cost_mem = {"ts": 0, "data": {}}
 
+_WEEKLY_COST_CACHE_TTL = 300  # 5 minutes
+_WEEKLY_COST_WINDOW = 7 * 86400
+_weekly_cost_mem = {"ts": 0, "data": {}}
+
+
+def _get_cached_weekly_cost():
+    """Rolling 7-day API-equivalent cost, with the same two-tier cache as the
+    cumulative figure: in-memory for the hot path, then a 5-minute disk cache
+    so a full transcript scan runs at most twice per refresh window.
+    """
+    now = time.time()
+
+    if now - _weekly_cost_mem["ts"] < _WEEKLY_COST_CACHE_TTL:
+        return _weekly_cost_mem["data"]
+
+    cache_path = get_state_dir() / "weekly_cost_cache.json"
+    try:
+        with open(cache_path, "r", encoding="utf-8") as f:
+            cached = json.load(f)
+        if now - cached.get("timestamp", 0) < _WEEKLY_COST_CACHE_TTL:
+            _weekly_cost_mem["ts"] = now
+            _weekly_cost_mem["data"] = cached.get("data", {})
+            return _weekly_cost_mem["data"]
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        pass
+
+    data = _scan_session_costs(since_ts=now - _WEEKLY_COST_WINDOW)
+    _weekly_cost_mem["ts"] = now
+    _weekly_cost_mem["data"] = data
+    try:
+        _atomic_json_write(cache_path, {"timestamp": now, "data": data}, indent=None)
+    except OSError:
+        pass
+    return data
+
 
 def _get_cached_cumulative_cost():
     """Return cumulative cost data with in-memory + 5-minute disk cache."""
@@ -2691,14 +2958,41 @@ def _get_cached_cumulative_cost():
     return data
 
 
-def _scan_session_costs():
-    """Scan all Claude Code session JSONL transcripts and calculate API-equivalent costs.
+def _parse_transcript_ts(value):
+    """Parse a transcript entry's ISO-8601 timestamp to a UTC epoch float.
+
+    Claude Code writes them Z-suffixed ("2026-07-18T15:01:07.532Z").
+    ``datetime.fromisoformat`` only learned to accept "Z" in Python 3.11, and
+    claude-pulse supports 3.8, so normalise it to an explicit offset first.
+    Returns None for anything unparseable.
+    """
+    if not value or not isinstance(value, str):
+        return None
+    try:
+        text = value.strip()
+        if text.endswith(("Z", "z")):
+            text = text[:-1] + "+00:00"
+        parsed = datetime.fromisoformat(text)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed.timestamp()
+    except (ValueError, TypeError, OverflowError, OSError):
+        return None
+
+
+def _scan_session_costs(since_ts=None):
+    """Scan Claude Code session JSONL transcripts for API-equivalent costs.
 
     Returns a dict with per-model cost/token breakdown, totals, session count,
     and the earliest file mtime seen.
+
+    When *since_ts* (a UTC epoch float) is given, only entries stamped at or
+    after it are counted, which is what the rolling weekly-cost widget needs.
+    Files whose mtime predates the cutoff are skipped outright — they cannot
+    contain newer entries — but the per-entry timestamp is still checked,
+    because a file touched today may hold months of history.
     """
-    home = Path.home()
-    projects_dir = home / ".claude" / "projects"
+    projects_dir = _claude_config_dir() / "projects"
 
     models: dict = {}
     total_cost_usd = 0.0
@@ -2721,6 +3015,14 @@ def _scan_session_costs():
         jsonl_files = []
 
     for jsonl_path in jsonl_files:
+        # Cheap prefilter: a file untouched since the cutoff has nothing new.
+        try:
+            mtime = jsonl_path.stat().st_mtime
+        except OSError:
+            mtime = None
+        if since_ts is not None and mtime is not None and mtime < since_ts:
+            continue
+
         # Count sessions: top-level JSONL files only (not inside subagents/ dirs)
         path_parts = jsonl_path.parts
         is_subagent = any(p == "subagents" for p in path_parts)
@@ -2728,12 +3030,8 @@ def _scan_session_costs():
             session_count += 1
 
         # Track earliest file mtime
-        try:
-            mtime = jsonl_path.stat().st_mtime
-            if first_seen_ts is None or mtime < first_seen_ts:
-                first_seen_ts = mtime
-        except OSError:
-            pass
+        if mtime is not None and (first_seen_ts is None or mtime < first_seen_ts):
+            first_seen_ts = mtime
 
         # Parse each line
         try:
@@ -2753,17 +3051,29 @@ def _scan_session_costs():
                         usage = msg.get("usage", {})
                         if not usage or "input_tokens" not in usage:
                             continue
+                        if since_ts is not None:
+                            entry_ts = _parse_transcript_ts(entry.get("timestamp"))
+                            # Drop undated entries too: counting them would
+                            # inflate a "last 7 days" figure with history.
+                            if entry_ts is None or entry_ts < since_ts:
+                                continue
                         model_id = msg.get("model", "")
                         # Normalise: strip version suffix variants for matching
-                        # e.g. "claude-sonnet-4-5-20251022" → "claude-sonnet-4-5"
+                        # e.g. "claude-sonnet-4-5-20251022" → "claude-sonnet-4-5".
+                        # Longest prefix wins — a first-match scan would let the
+                        # bare "claude-opus-4" key ($15/$75) swallow
+                        # "claude-opus-4-8" ($5/$25) and treble the reported cost.
                         pricing = API_PRICING.get(model_id)
                         if pricing is None:
-                            # Try prefix match (handles dated variants)
+                            best_key = None
                             for key in API_PRICING:
-                                if model_id.startswith(key):
-                                    pricing = API_PRICING[key]
-                                    model_id = key
-                                    break
+                                if model_id.startswith(key) and (
+                                    best_key is None or len(key) > len(best_key)
+                                ):
+                                    best_key = key
+                            if best_key is not None:
+                                pricing = API_PRICING[best_key]
+                                model_id = best_key
                         if pricing is None:
                             continue
 
@@ -2873,7 +3183,10 @@ def cmd_stats():
                 f"{BRIGHT_YELLOW}{cost_str:<12}{RESET}{DIM}({tok_str}){RESET}"
             )
 
-        utf8_print(f"    {DIM}{'\u2500' * 33}{RESET}")
+        # Built outside the f-string: a backslash escape inside an f-string
+        # expression is a SyntaxError before Python 3.12 (PEP 701).
+        _sep = "\u2500" * 33
+        utf8_print(f"    {DIM}{_sep}{RESET}")
         total_local = cost_data["total_cost_usd"] * rate
         utf8_print(f"    {'Total:':<{max_name_len + 2}}  {BOLD}{BRIGHT_YELLOW}{currency_sym}{total_local:,.2f}{RESET}")
         utf8_print("")
@@ -2926,7 +3239,8 @@ def _parse_stdin_context(raw_stdin):
         else:
             model_id = model.get("id", "")
             if model_id:
-                result["model_name"] = MODEL_SHORT_NAMES.get(model_id, _sanitize(model_id.split("-")[-1].title()))
+                short = _model_short_name(model_id)
+                result["model_name"] = short or _sanitize(model_id.split("-")[-1].title())
     except (AttributeError, KeyError):
         pass
 
@@ -2958,6 +3272,80 @@ def _parse_stdin_context(raw_stdin):
             result["lines_added"] = int(lines_added or 0)
             result["lines_removed"] = int(lines_removed or 0)
     except (AttributeError, KeyError, ValueError, TypeError):
+        pass
+
+    # Running Claude Code version. Used by the update check so it doesn't have
+    # to shell out to `claude --version` on every repaint.
+    try:
+        version = data.get("data", data).get("version")
+        if version:
+            result["cc_version"] = _sanitize(str(version))
+    except (AttributeError, KeyError, TypeError):
+        pass
+
+    # Reasoning effort, fast mode and thinking state.
+    #
+    # Claude Code reports the session's effort on stdin as `effort.level`.
+    # Earlier versions of claude-pulse read a CLAUDE_CODE_EFFORT_LEVEL
+    # environment variable instead, which Claude Code does not actually export
+    # — so the effort widget only ever rendered for users who happened to set
+    # that variable by hand. stdin is the real source; the env var is kept
+    # below as a fallback for anyone relying on the old behaviour.
+    try:
+        payload = data.get("data", data)
+        effort = payload.get("effort")
+        if isinstance(effort, dict):
+            level = _sanitize(str(effort.get("level") or ""))
+            if level and level != "unset":
+                result["effort"] = level
+        if payload.get("fast_mode") is True:
+            result["fast_mode"] = True
+        thinking = payload.get("thinking")
+        if isinstance(thinking, dict) and thinking.get("enabled") is not None:
+            result["thinking"] = bool(thinking.get("enabled"))
+    except (AttributeError, KeyError, TypeError, ValueError):
+        pass
+
+    # Active subagent (agent.name) — present while a subagent drives the turn.
+    try:
+        agent = data.get("data", data).get("agent")
+        if isinstance(agent, dict):
+            name = _sanitize(agent.get("name", ""))
+            if name:
+                result["agent_name"] = name
+    except (AttributeError, KeyError, TypeError):
+        pass
+
+    # Pull request context (number / url / review_state).
+    try:
+        pr = data.get("data", data).get("pr")
+        if isinstance(pr, dict) and pr.get("number") is not None:
+            result["pr_number"] = int(pr["number"])
+            url = _sanitize(pr.get("url", ""))
+            # Only accept http(s) — the URL is embedded in an OSC 8 hyperlink,
+            # so a javascript:/file: scheme must never reach the terminal.
+            if url.startswith(("https://", "http://")):
+                result["pr_url"] = url
+            state = _sanitize(pr.get("review_state", ""))
+            if state:
+                result["pr_review_state"] = state
+    except (AttributeError, KeyError, TypeError, ValueError):
+        pass
+
+    # Cache efficiency from the current_usage breakdown. cache_read is billed
+    # at ~0.1x input, so the share of input served from cache is the single
+    # most useful cost signal available on stdin.
+    try:
+        cur = data.get("data", data).get("context_window", {}).get("current_usage", {})
+        if isinstance(cur, dict):
+            cache_read = int(cur.get("cache_read_input_tokens") or 0)
+            cache_creation = int(cur.get("cache_creation_input_tokens") or 0)
+            fresh_input = int(cur.get("input_tokens") or 0)
+            billable = cache_read + cache_creation + fresh_input
+            if billable > 0:
+                result["cache_read_tokens"] = cache_read
+                result["cache_hit_pct"] = (cache_read / billable) * 100.0
+    except (AttributeError, KeyError, TypeError, ValueError):
         pass
 
     # Worktree (v2.1.69+)
@@ -3510,11 +3898,16 @@ def build_status_line(usage, plan, config=None, stdin_ctx=None, cache_age=None):
     except Exception:
         pass  # if width detection/clamping fails, use configured bar size
 
-    parts = []  # list of (priority, text) tuples — sorted before joining
+    # list of ((priority, widget_id), text) tuples — sorted before joining.
+    # The key carries the widget id so the two-line splitter can tell which
+    # segment is which without every append site having to pass it along;
+    # tuple ordering still sorts by priority first, with the id as a stable
+    # tie-break.
+    parts = []
     _wpri = dict(WIDGET_PRIORITY)
     _wpri.update(config.get("widget_priority", {}))
     def _pri(widget_id):
-        return _wpri.get(widget_id, 999)
+        return (_wpri.get(widget_id, 999), widget_id)
 
     # Current Session (5-hour block)
     if show.get("session", True):
@@ -3620,53 +4013,39 @@ def build_status_line(usage, plan, config=None, stdin_ctx=None, cache_age=None):
             else:
                 parts.append((_w, f"Weekly {bar} {pct:.0f}%{pace_str}{weekly_reset_str}"))
 
-    # Opus weekly limit
-    if show.get("opus", True):
-        opus = usage.get("seven_day_opus")
-        if opus and opus.get("utilization") is not None:
-            pct = opus.get("utilization") or 0
-            bar = make_bar(pct, theme, plain=bar_plain, width=bw, bar_style=bstyle)
-            _o = _pri("opus")
-            if layout == "compact":
-                parts.append((_o, f"O {bar} {pct:.0f}%"))
-            elif layout == "minimal":
-                parts.append((_o, f"{bar} {pct:.0f}%"))
-            elif layout == "percent-first":
-                parts.append((_o, f"{pct:.0f}% {bar}"))
-            else:
-                parts.append((_o, f"Opus {bar} {pct:.0f}%"))
-
-    # Sonnet weekly limit
-    if show.get("sonnet", True):
-        sonnet = usage.get("seven_day_sonnet")
-        if sonnet and sonnet.get("utilization") is not None:
-            pct = sonnet.get("utilization") or 0
-            bar = make_bar(pct, theme, plain=bar_plain, width=bw, bar_style=bstyle)
-            pace_str = ""
-            if show.get("pace"):
-                pace = _calc_pace_pct(sonnet.get("resets_at"), 604800)
-                if pace is not None:
-                    pace_str = f" ({pace:.0f}%)"
-            _sn = _pri("sonnet")
-            if layout == "compact":
-                parts.append((_sn, f"S {bar} {pct:.0f}%{pace_str}"))
-            elif layout == "minimal":
-                parts.append((_sn, f"{bar} {pct:.0f}%{pace_str}"))
-            elif layout == "percent-first":
-                parts.append((_sn, f"{pct:.0f}%{pace_str} {bar}"))
-            else:
-                parts.append((_sn, f"Sonnet {bar} {pct:.0f}%{pace_str}"))
+    # Per-model weekly caps (Opus / Sonnet / Fable).
+    #
+    # These are rendered only when the API actually reports a utilization for
+    # that model. Claude Pro returns null for the model-scoped windows, so on
+    # Pro these bars are simply absent — v3.1.0 drew a hardcoded "Sonnet ━ 0%"
+    # in that case, which looked like a real reading of an untouched budget
+    # rather than "no data" (issue #46).
+    for _widget_id, _usage_key, _label, _short in (
+        ("opus", "seven_day_opus", "Opus", "O"),
+        ("sonnet", "seven_day_sonnet", "Sonnet", "S"),
+        ("fable", "seven_day_fable", "Fable", "F"),
+    ):
+        if not show.get(_widget_id, True):
+            continue
+        _entry = usage.get(_usage_key)
+        if not _entry or _entry.get("utilization") is None:
+            continue
+        pct = _entry.get("utilization") or 0
+        bar = make_bar(pct, theme, plain=bar_plain, width=bw, bar_style=bstyle)
+        pace_str = ""
+        if show.get("pace"):
+            pace = _calc_pace_pct(_entry.get("resets_at"), 604800)
+            if pace is not None:
+                pace_str = f" ({pace:.0f}%)"
+        _p = _pri(_widget_id)
+        if layout == "compact":
+            parts.append((_p, f"{_short} {bar} {pct:.0f}%{pace_str}"))
+        elif layout == "minimal":
+            parts.append((_p, f"{bar} {pct:.0f}%{pace_str}"))
+        elif layout == "percent-first":
+            parts.append((_p, f"{pct:.0f}%{pace_str} {bar}"))
         else:
-            bar = make_bar(0, theme, plain=bar_plain, width=bw, bar_style=bstyle)
-            _sn = _pri("sonnet")
-            if layout == "compact":
-                parts.append((_sn, f"S {bar} 0%"))
-            elif layout == "minimal":
-                parts.append((_sn, f"{bar} 0%"))
-            elif layout == "percent-first":
-                parts.append((_sn, f"0% {bar}"))
-            else:
-                parts.append((_sn, f"Sonnet {bar} 0%"))
+            parts.append((_p, f"{_label} {bar} {pct:.0f}%{pace_str}"))
 
     # Extra usage (bonus/gifted credits)
     extra = usage.get("extra_usage")
@@ -3766,6 +4145,19 @@ def build_status_line(usage, plan, config=None, stdin_ctx=None, cache_age=None):
         except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
             pass
 
+    # Rolling 7-day API-equivalent cost (opt-in, off by default)
+    if show.get("weekly_cost", False):
+        try:
+            wdata = _get_cached_weekly_cost()
+            wtotal = wdata.get("total_cost_usd", 0.0)
+            if wtotal > 0:
+                currency = _sanitize(config.get("currency", "$"))[:5]
+                rate, code = _get_exchange_rate(currency)
+                sym = "$" if code == "USD" else currency
+                parts.append((_pri("weekly_cost"), f"{DIM}7d:{RESET} {sym}{wtotal * rate:,.2f}"))
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+            pass
+
     # Lines changed (from stdin cost data)
     if stdin_ctx and show.get("lines", True):
         la = stdin_ctx.get("lines_added")
@@ -3775,17 +4167,6 @@ def build_status_line(usage, plan, config=None, stdin_ctx=None, cache_age=None):
             r = int(lr or 0)
             if a > 0 or r > 0:
                 parts.append((_pri("lines"), f"{BRIGHT_GREEN}+{a}{RESET} {BRIGHT_RED}-{r}{RESET}"))
-
-    # Peak hours indicator
-    is_peak, peak_str = _check_peak_hours(config)
-    if peak_str:
-        _pk = _pri("peak")
-        if is_peak:
-            parts.append((_pk, f"{RED}{peak_str}{RESET}"))
-        elif "in " in peak_str:
-            parts.append((_pk, f"{YELLOW}{peak_str}{RESET}"))
-        else:
-            parts.append((_pk, f"{GREEN}{peak_str}{RESET}"))
 
     # Plan name (hidden in minimal layout)
     if layout != "minimal" and show.get("plan", True) and plan:
@@ -3809,13 +4190,63 @@ def build_status_line(usage, plan, config=None, stdin_ctx=None, cache_age=None):
             if model:
                 parts.append((_pri("model"), model))
 
-    # Effort level
+    # Effort level — from stdin, falling back to the legacy env var.
     if show.get("effort", True):
-        effort = os.environ.get("CLAUDE_CODE_EFFORT_LEVEL", "")
+        effort = (stdin_ctx or {}).get("effort") or os.environ.get("CLAUDE_CODE_EFFORT_LEVEL", "")
         if effort and effort != "unset":
             effort = _sanitize(effort)
-            effort_short = {"medium": "med"}.get(effort, effort)
-            parts.append((_pri("effort"), effort_short))
+            effort_short = EFFORT_SHORT.get(effort, effort)
+            colour = EFFORT_COLOURS.get(effort, "")
+            parts.append((_pri("effort"), f"{colour}{effort_short}{RESET}" if colour else effort_short))
+
+    # Fast mode — Opus running at up to 2.5x output speed, premium pricing.
+    # Worth flagging precisely because it costs more than standard Opus.
+    if stdin_ctx and show.get("fast_mode", True) and stdin_ctx.get("fast_mode"):
+        parts.append((_pri("fast_mode"), f"{BRIGHT_YELLOW}⚡fast{RESET}"))
+
+    # Thinking indicator (opt-in — on by default on current models, so it is
+    # only interesting to users who toggle it).
+    if stdin_ctx and show.get("thinking", False):
+        thinking = stdin_ctx.get("thinking")
+        if thinking is not None:
+            if thinking:
+                parts.append((_pri("thinking"), f"{DIM}think{RESET}"))
+            else:
+                parts.append((_pri("thinking"), f"{DIM}no-think{RESET}"))
+
+    # Active subagent
+    if stdin_ctx and show.get("agent", True):
+        agent_name = stdin_ctx.get("agent_name")
+        if agent_name:
+            parts.append((_pri("agent"), f"{MAGENTA}▸{agent_name}{RESET}"))
+
+    # Cache hit rate (opt-in) — share of billable input served from cache.
+    if stdin_ctx and show.get("cache", False):
+        hit = stdin_ctx.get("cache_hit_pct")
+        if hit is not None:
+            # High cache hit is good, so colour it inverted relative to the
+            # usage bars: green when most input is cached, red when little is.
+            if hit >= 70:
+                colour = GREEN
+            elif hit >= 40:
+                colour = YELLOW
+            else:
+                colour = RED
+            if layout == "minimal":
+                parts.append((_pri("cache"), f"{colour}{hit:.0f}%{RESET}"))
+            else:
+                parts.append((_pri("cache"), f"{DIM}cache{RESET} {colour}{hit:.0f}%{RESET}"))
+
+    # Pull request badge (opt-in), clickable via OSC 8 where supported.
+    if stdin_ctx and show.get("pr", False):
+        pr_number = stdin_ctx.get("pr_number")
+        if pr_number is not None:
+            state = stdin_ctx.get("pr_review_state", "")
+            colour = PR_STATE_COLOURS.get(state, CYAN)
+            label = f"#{pr_number}"
+            if state:
+                label += f" {PR_STATE_GLYPHS.get(state, state)}"
+            parts.append((_pri("pr"), _osc8(stdin_ctx.get("pr_url"), f"{colour}{label}{RESET}")))
 
     # Worktree branch
     if stdin_ctx and show.get("worktree", True):
@@ -3888,7 +4319,7 @@ def build_status_line(usage, plan, config=None, stdin_ctx=None, cache_age=None):
 
     # Sort widgets by priority, then join
     parts.sort(key=lambda x: x[0])
-    line = " | ".join(p[1] for p in parts)
+    line = _join_parts(parts, config)
 
     # Staleness indicator
     if show.get("staleness", True) and cache_age is not None:
@@ -3911,16 +4342,105 @@ def build_status_line(usage, plan, config=None, stdin_ctx=None, cache_age=None):
     return line
 
 
+def _join_parts(parts, config):
+    """Join sorted widget segments into one or two rows.
+
+    Claude Code renders each line of stdout as its own status row, so a
+    deliberate two-row layout is just a newline. Two opt-in config keys drive
+    it, both lists of widget ids:
+
+    * ``line1_widgets`` — allowlist for row 1; everything else flows to row 2.
+    * ``line2_widgets`` — explicit push to row 2; everything else stays on row 1.
+
+    ``line1_widgets`` wins if both are set. With neither, everything stays on a
+    single row and the existing ``--wrap`` handling applies as before. A row
+    that ends up empty is dropped rather than emitted blank.
+    """
+    if not isinstance(config, dict):
+        return " | ".join(p[1] for p in parts)
+    line1_ids = config.get("line1_widgets") or []
+    line2_ids = config.get("line2_widgets") or []
+    if not isinstance(line1_ids, list):
+        line1_ids = []
+    if not isinstance(line2_ids, list):
+        line2_ids = []
+    if not line1_ids and not line2_ids:
+        return " | ".join(p[1] for p in parts)
+
+    if line1_ids:
+        allow = set(line1_ids)
+        on_row1 = [p for p in parts if p[0][1] in allow]
+        on_row2 = [p for p in parts if p[0][1] not in allow]
+    else:
+        demote = set(line2_ids)
+        on_row1 = [p for p in parts if p[0][1] not in demote]
+        on_row2 = [p for p in parts if p[0][1] in demote]
+
+    rows = [" | ".join(p[1] for p in row) for row in (on_row1, on_row2)]
+    return "\n".join(r for r in rows if r)
+
+
+OSC8_START = "\033]8;;"
+OSC8_END = "\033]8;;\a"
+
+# Final bytes that terminate a CSI (colour) sequence.
+_CSI_TERMINATORS = "ABCDEFGHJKSTfmnsulh"
+
+
+def _skip_escape(text, i):
+    """Return the index just past the escape sequence starting at ``text[i]``.
+
+    Handles the two forms the status line emits:
+
+    * CSI colour codes — ``ESC [ ... <letter>``, short and self-terminating.
+    * OSC 8 hyperlinks — ``ESC ] 8 ; ; <url> BEL``. These matter because a URL
+      contains letters from the CSI terminator set (the ``h`` of ``https``), so
+      scanning for a CSI terminator would stop inside the URL and count the
+      rest of it as visible width.
+
+    ``i`` must point at an ESC. Callers use this for width maths, so an
+    unterminated sequence consumes the remainder rather than looping.
+    """
+    n = len(text)
+    if i + 1 < n and text[i + 1] == "]":
+        # OSC — runs until BEL or the ST terminator (ESC backslash).
+        j = i + 2
+        while j < n:
+            if text[j] == "\a":
+                return j + 1
+            if text[j] == "\033" and j + 1 < n and text[j + 1] == "\\":
+                return j + 2
+            j += 1
+        return n
+    # CSI (or a bare ESC followed by a final byte).
+    j = i + 1
+    while j < n and j < i + 25 and text[j] not in _CSI_TERMINATORS:
+        j += 1
+    return j + 1 if j < n else j
+
+
+def _osc8(url, label):
+    """Wrap *label* in an OSC 8 hyperlink when *url* is usable.
+
+    Terminals without hyperlink support ignore the escape and show the label
+    unchanged, so this is safe to emit unconditionally. Returns the bare label
+    when there is no URL, or when it contains control characters that would
+    let it break out of the escape sequence.
+    """
+    if not url:
+        return label
+    if any(ch in url for ch in ("\a", "\033", "\n", "\r", ";")):
+        return label
+    return f"{OSC8_START}{url}\a{label}{OSC8_END}"
+
+
 def _visible_len(text):
     """Return the number of visible (non-ANSI-escape) characters in *text*."""
     count = 0
     i = 0
     while i < len(text):
         if text[i] == "\033":
-            j = i + 1
-            while j < len(text) and j < i + 25 and text[j] not in "ABCDEFGHJKSTfmnsulh":
-                j += 1
-            i = j + 1 if j < len(text) else j
+            i = _skip_escape(text, i)
             continue
         count += 1
         i += 1
@@ -3942,21 +4462,26 @@ def _truncate_line(line, config):
         visible_count = 0
         cut = None
         i = 0
+        in_link = False
+        cut_in_link = False
         while i < len(line):
             if line[i] == "\033":
-                # Skip ANSI escape sequence
-                j = i + 1
-                while j < len(line) and j < i + 25 and line[j] not in "ABCDEFGHJKSTfmnsulh":
-                    j += 1
-                i = j + 1 if j < len(line) else j
+                nxt = _skip_escape(line, i)
+                # Track hyperlink nesting so a cut inside one can be closed.
+                if line.startswith(OSC8_START, i):
+                    in_link = line[i:nxt] != OSC8_END
+                i = nxt
                 continue
             visible_count += 1
             if visible_count > max_visible:
                 cut = i
+                cut_in_link = in_link
                 break
             i += 1
         if cut is not None:
-            line = line[:cut] + RESET
+            # Close a hyperlink we cut through, or the terminal treats every
+            # following line as part of the link target.
+            line = line[:cut] + (OSC8_END if cut_in_link else "") + RESET
     except Exception:
         pass
     return line
@@ -4011,7 +4536,15 @@ def _wrap_line(line, config):
 
 
 def _fit_line(line, config):
-    """Apply wrap or truncate depending on the user's --wrap setting."""
+    """Apply wrap or truncate depending on the user's --wrap setting.
+
+    The line may already be two rows when ``line1_widgets`` / ``line2_widgets``
+    are configured. Each row is fitted independently — measuring the joined
+    string would count the newline as a visible column and truncate the rows
+    against a shared budget they don't actually share.
+    """
+    if "\n" in line:
+        return "\n".join(_fit_line(row, config) for row in line.split("\n"))
     if config.get("wrap") == "auto":
         return _wrap_line(line, config)
     return _truncate_line(line, config)
@@ -4051,8 +4584,85 @@ def _get_python_cmd():
     return exe
 
 
+# Refresh cadences (seconds) for `statusLine.refreshInterval`, chosen by what
+# is actually on screen. Claude Code enforces a minimum of 1.
+REFRESH_ANIMATED = 2      # animations repaint every tick
+REFRESH_TIMED = 15        # focus countdown / heartbeat elapsed time
+REFRESH_STATIC = None     # nothing time-based — stay purely event-driven
+
+
+def _desired_refresh_interval(config):
+    """Return the `refreshInterval` this config needs, or None for event-driven.
+
+    Claude Code redraws the status line on its own events (prompt submit, tool
+    use, and so on), which is enough for anything derived from stdin. It is not
+    enough for content that changes with the wall clock: animation frames, the
+    focus-timer countdown, and the heartbeat's elapsed time all freeze while
+    the session sits idle. `refreshInterval` re-runs the command on a timer to
+    cover exactly those cases.
+
+    We only ask for a timer when something needs it, so a static bar costs
+    nothing extra.
+    """
+    if not isinstance(config, dict):
+        return REFRESH_STATIC
+    if config.get("animate", "off") != "off":
+        return REFRESH_ANIMATED
+    show = config.get("show", {})
+    if not isinstance(show, dict):
+        show = {}
+    if show.get("heartbeat", True) or show.get("pomodoro", True):
+        return REFRESH_TIMED
+    return REFRESH_STATIC
+
+
+def sync_status_line_refresh(config=None):
+    """Re-point `statusLine.refreshInterval` at what the current config needs.
+
+    Called after any setting that changes the answer (animation mode, focus
+    timer, widget visibility). Rewrites only that one key, leaving the rest of
+    settings.json untouched, and is a no-op when claude-pulse is not the
+    installed status line — we must never edit another tool's block.
+
+    Returns the interval that was written (None when the key was removed), or
+    False when nothing was done.
+    """
+    settings_path = _claude_config_dir() / "settings.json"
+    try:
+        with open(settings_path, "r", encoding="utf-8") as f:
+            settings = json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return False
+    status_line = settings.get("statusLine")
+    if not isinstance(status_line, dict):
+        return False
+    # Only touch our own status line.
+    if "claude_status.py" not in str(status_line.get("command", "")):
+        return False
+
+    if config is None:
+        config = load_config()
+    interval = _desired_refresh_interval(config)
+
+    current = status_line.get("refreshInterval")
+    had_legacy = "refresh" in status_line
+    if current == interval and not had_legacy:
+        return interval  # already correct
+
+    status_line.pop("refresh", None)  # never a real Claude Code setting
+    if interval is None:
+        status_line.pop("refreshInterval", None)
+    else:
+        status_line["refreshInterval"] = interval
+    try:
+        _atomic_json_write(settings_path, settings)
+    except OSError:
+        return False
+    return interval
+
+
 def install_status_line():
-    settings_path = Path.home() / ".claude" / "settings.json"
+    settings_path = _claude_config_dir() / "settings.json"
     script_path = _win_portable_path(Path(__file__).resolve())
     python_cmd = _get_python_cmd()
 
@@ -4069,11 +4679,17 @@ def install_status_line():
             return
 
     # Status line command — use $HOME on Windows for Claude Code compat
-    settings["statusLine"] = {
+    status_line = {
         "type": "command",
         "command": f'{python_cmd} "{script_path}"',
-        "refresh": 150,
     }
+    # Versions up to v3.1.0 wrote `"refresh": 150` here. Claude Code has no
+    # such setting, so it was silently ignored and the timed repaint never
+    # happened. The real key is `refreshInterval`, in seconds.
+    interval = _desired_refresh_interval(load_config())
+    if interval is not None:
+        status_line["refreshInterval"] = interval
+    settings["statusLine"] = status_line
 
     # No hooks installed here — static status bar by default.
     # Use --animate on for always-on animation (installs hooks automatically)
@@ -4084,6 +4700,10 @@ def install_status_line():
 
     utf8_print(f"Installed status line to {settings_path}")
     utf8_print(f"Command: {python_cmd} \"{script_path}\"")
+    if interval is not None:
+        utf8_print(f"Refresh: every {interval}s (plus Claude Code's own events)")
+    else:
+        utf8_print("Refresh: event-driven (no timer needed for a static bar)")
     utf8_print("Restart Claude Code to see the status line.")
     utf8_print("Tip: use --animate on for always-on rainbow animation.")
 
@@ -4102,7 +4722,7 @@ def install_pulse_command():
         utf8_print("      Re-run the full installer (install.sh / install.ps1) to add it.")
         return
 
-    commands_dir = Path.home() / ".claude" / "commands"
+    commands_dir = _claude_config_dir() / "commands"
     dest = commands_dir / "pulse.md"
     try:
         _secure_mkdir(commands_dir)
@@ -5139,46 +5759,6 @@ def main():
             utf8_print("Usage: --animation-speed <slow|normal|fast>")
         return
 
-    if "--peak-hours" in args:
-        idx = args.index("--peak-hours")
-        if idx + 1 < len(args):
-            val = args[idx + 1].lower()
-            config = load_config()
-            if val in ("off", "false", "no", "0"):
-                config["peak_hours"]["enabled"] = False
-                save_config(config)
-                utf8_print(f"Peak hours: {RED}off{RESET}")
-            elif val in ("on", "true", "yes", "1"):
-                config["peak_hours"]["enabled"] = True
-                save_config(config)
-                start = config["peak_hours"]["start"]
-                end = config["peak_hours"]["end"]
-                utf8_print(f"Peak hours: {GREEN}on{RESET}  ({start} - {end} local time)")
-            elif ":" in val or "-" in val:
-                # Parse "13:00-19:00" or "13:00" as start with optional end
-                parts_str = val.replace(" ", "").split("-")
-                start = parts_str[0]
-                end = parts_str[1] if len(parts_str) > 1 else args[idx + 2] if idx + 2 < len(args) else None
-                if not end:
-                    utf8_print("Usage: --peak-hours 13:00-19:00")
-                    return
-                config["peak_hours"]["enabled"] = True
-                config["peak_hours"]["start"] = start
-                config["peak_hours"]["end"] = end
-                save_config(config)
-                utf8_print(f"Peak hours: {GREEN}{start} - {end}{RESET} (local time)")
-            else:
-                utf8_print("Usage: --peak-hours on|off|HH:MM-HH:MM")
-                utf8_print(f"  on              Enable peak indicator")
-                utf8_print(f"  off             Disable peak indicator")
-                utf8_print(f"  13:00-19:00     Set custom peak window (local time)")
-        else:
-            config = load_config()
-            peak = config.get("peak_hours", {})
-            state = f"{GREEN}on{RESET}" if peak.get("enabled") else f"{RED}off{RESET}"
-            utf8_print(f"Peak hours: {state}  ({peak.get('start', '13:00')} - {peak.get('end', '19:00')} local time)")
-        return
-
     if "--config" in args:
         cmd_print_config()
         return
@@ -5282,7 +5862,7 @@ def main():
         write_cache(cache_path, line, usage_from_stdin, plan_from_cache)
 
         line = append_update_indicator(line, config)
-        line = append_claude_update_indicator(line, config)
+        line = append_claude_update_indicator(line, config, stdin_ctx)
         line = _fit_line(line, config)
         sys.stdout.buffer.write((line + RESET + "\n").encode("utf-8"))
         return
@@ -5296,7 +5876,7 @@ def main():
         else:
             line = cached.get("line", "")
         line = append_update_indicator(line, config)
-        line = append_claude_update_indicator(line, config)
+        line = append_claude_update_indicator(line, config, stdin_ctx)
         line = _fit_line(line, config)
         sys.stdout.buffer.write((line + RESET + "\n").encode("utf-8"))
         return
@@ -5331,26 +5911,34 @@ def main():
         elif e.code == 403:
             line = "Access denied \u2014 check your subscription"
         elif e.code == 429:
+            # Exponential backoff, persisted so the *next* invocation also
+            # holds off. Previously a 429 with usable stale data wrote nothing
+            # back, so every refresh retried immediately and kept the limit lit.
             stale = _read_stale_cache(cache_path)
+            delay, fails = _rate_limit_backoff((stale or {}).get("rate_limit_fails"))
+            retry_at = time.time() + delay
+
             stale_usage = stale.get("usage") if stale else None
             if stale_usage:
                 usage = stale_usage
                 stale_age = time.time() - stale.get("timestamp", time.time())
-                line = build_status_line(usage, stale.get("plan", plan), config, stdin_ctx, cache_age=stale_age)
+                line = build_status_line(
+                    usage, stale.get("plan", plan), config, stdin_ctx, cache_age=stale_age
+                )
+                write_cache(
+                    cache_path, line, usage, stale.get("plan", plan),
+                    rate_limited_until=retry_at, rate_limit_fails=fails,
+                )
             else:
-                line = "Rate limited \u2014 retrying in 2 min"
-                # Write with rate_limited flag so cache uses longer backoff TTL
-                write_cache(cache_path, line)
-                try:
-                    with open(cache_path, "r", encoding="utf-8") as f:
-                        rl_data = json.load(f)
-                    rl_data["rate_limited"] = True
-                    with _secure_open_write(cache_path) as f:
-                        json.dump(rl_data, f)
-                except (OSError, json.JSONDecodeError):
-                    pass
-                sys.stdout.buffer.write((line + RESET + "\n").encode("utf-8"))
-                return
+                mins = max(1, int(delay // 60))
+                line = f"Rate limited \u2014 retrying in {mins} min"
+                write_cache(
+                    cache_path, line,
+                    rate_limited_until=retry_at, rate_limit_fails=fails,
+                )
+            line = _fit_line(line, config)
+            sys.stdout.buffer.write((line + RESET + "\n").encode("utf-8"))
+            return
         else:
             line = f"API error: {e.code}"
     except urllib.error.URLError as e:
@@ -5396,7 +5984,7 @@ def main():
         # Cache error lines so we don't hammer the API on every refresh
         write_cache(cache_path, line)
     line = append_update_indicator(line, config)
-    line = append_claude_update_indicator(line, config)
+    line = append_claude_update_indicator(line, config, stdin_ctx)
     line = _fit_line(line, config)
     sys.stdout.buffer.write((line + RESET + "\n").encode("utf-8"))
 

--- a/claude_status.py
+++ b/claude_status.py
@@ -3366,9 +3366,19 @@ def _parse_stdin_context(raw_stdin):
         rl = data.get("data", data).get("rate_limits", {})
         if rl:
             result["_rate_limits"] = {}
-            for window in ("five_hour", "seven_day", "seven_day_opus", "seven_day_sonnet"):
+            # Take the two fixed windows plus every model-scoped weekly cap
+            # Claude Code reports (seven_day_opus, seven_day_sonnet,
+            # seven_day_fable, ...). Enumerating rather than hardcoding means a
+            # new model shows up without another release — the previous fixed
+            # tuple silently dropped Fable.
+            windows = ["five_hour", "seven_day"]
+            windows += sorted(
+                k for k in rl
+                if isinstance(k, str) and k.startswith("seven_day_")
+            )
+            for window in windows:
                 w = rl.get(window)
-                if w and w.get("used_percentage") is not None:
+                if isinstance(w, dict) and w.get("used_percentage") is not None:
                     # Convert Unix epoch seconds to ISO string for compatibility
                     # with existing format_reset_time / format_weekly_reset
                     resets_at = w.get("resets_at")
@@ -5789,7 +5799,18 @@ def main():
     # survives across refreshes that don't receive stdin data from Claude Code.
     # Merge new data into persisted data so partial updates (e.g. model but
     # no context_pct during thinking) don't wipe previously known fields.
-    _STDIN_CTX_KEYS = {"model_name", "context_pct", "context_used", "context_limit", "cost_usd", "worktree_branch", "_rate_limits", "lines_added", "lines_removed"}
+    # Fields worth carrying across a refresh that arrives without stdin.
+    # Deliberately excludes `agent_name`: a subagent name is only true for the
+    # turn it ran on, so persisting it would leave a stale "▸reviewer" pinned
+    # to the bar long after that subagent finished.
+    _STDIN_CTX_KEYS = {
+        "model_name", "context_pct", "context_used", "context_limit",
+        "cost_usd", "worktree_branch", "_rate_limits",
+        "lines_added", "lines_removed",
+        "effort", "fast_mode", "thinking", "cc_version",
+        "cache_hit_pct", "cache_read_tokens",
+        "pr_number", "pr_url", "pr_review_state",
+    }
     stdin_ctx_path = get_state_dir() / "stdin_ctx.json"
     persisted = {}
     try:
@@ -5814,33 +5835,36 @@ def main():
     # The API is only needed for extra credits and per-model caps (opus/sonnet).
     stdin_rl = stdin_ctx.get("_rate_limits")
     if stdin_rl:
-        # Build a synthetic usage dict from stdin rate limits
-        usage_from_stdin = {}
-        if "five_hour" in stdin_rl:
-            usage_from_stdin["five_hour"] = stdin_rl["five_hour"]
-        if "seven_day" in stdin_rl:
-            usage_from_stdin["seven_day"] = stdin_rl["seven_day"]
+        # Build a synthetic usage dict from stdin rate limits. Take *every*
+        # window stdin offers, including the model-scoped weekly caps
+        # (seven_day_opus / _sonnet / _fable). Previously only five_hour and
+        # seven_day were copied and the per-model caps were re-fetched over
+        # OAuth — which both dropped Fable entirely and made a network call for
+        # data Claude Code had already handed us.
+        usage_from_stdin = {k: v for k, v in stdin_rl.items() if v}
+        has_model_caps = any(k.startswith("seven_day_") for k in usage_from_stdin)
 
-        # Merge with cached API data for extra/opus/sonnet if available
-        has_model_caps = False
+        # extra_usage (bonus credits) is never on stdin, so it still comes from
+        # cache, and from the API only if we have nothing cached at all.
+        plan_from_cache = ""
         if cached and "usage" in cached:
-            for key in ("extra_usage", "seven_day_opus", "seven_day_sonnet"):
-                if key in cached["usage"]:
-                    usage_from_stdin[key] = cached["usage"][key]
-                    has_model_caps = True
             plan_from_cache = cached.get("plan", "")
-        else:
-            plan_from_cache = ""
+            for key, value in cached["usage"].items():
+                if key not in usage_from_stdin:
+                    usage_from_stdin[key] = value
+                    if key.startswith("seven_day_"):
+                        has_model_caps = True
+                if key == "extra_usage":
+                    has_model_caps = has_model_caps or True
 
-        # If no per-model data cached, fetch from API once to populate it
-        if not has_model_caps:
+        if not has_model_caps and "extra_usage" not in usage_from_stdin:
             try:
                 token, api_plan = get_credentials()
                 if token:
                     api_usage = fetch_usage(token)
-                    for key in ("extra_usage", "seven_day_opus", "seven_day_sonnet"):
-                        if key in api_usage:
-                            usage_from_stdin[key] = api_usage[key]
+                    for key, value in api_usage.items():
+                        if key in _USAGE_CACHE_KEYS and key not in usage_from_stdin:
+                            usage_from_stdin[key] = value
                     if api_plan:
                         plan_from_cache = api_plan
                     write_cache(cache_path, "", usage=api_usage, plan=plan_from_cache)

--- a/claude_status.py
+++ b/claude_status.py
@@ -1392,6 +1392,18 @@ def _remote_is_ancestor(remote):
     return None  # any other status means git could not answer
 
 
+def _cache_age(cached):
+    """Age in seconds of a cache dict, or +inf when its timestamp is unusable.
+
+    Returning infinity makes a corrupt entry look infinitely stale, so callers
+    naturally fall through to a fresh check instead of raising on the subtraction.
+    """
+    try:
+        return time.time() - float(cached.get("timestamp", 0) or 0)
+    except (AttributeError, TypeError, ValueError):
+        return float("inf")
+
+
 def check_for_update():
     """Check if a newer version is available on GitHub. Returns True/False/None.
 
@@ -1416,8 +1428,10 @@ def check_for_update():
             cached = json.load(f)
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         cached = None
+    if not isinstance(cached, dict):
+        cached = None
 
-    if cached and time.time() - cached.get("timestamp", 0) < UPDATE_CHECK_TTL:
+    if cached and _cache_age(cached) < UPDATE_CHECK_TTL:
         if script_mtime is not None and cached.get("script_mtime") == script_mtime:
             return cached.get("update_available", False)
 
@@ -1427,7 +1441,7 @@ def check_for_update():
         return None  # not a git install, skip silently
 
     if (cached
-            and time.time() - cached.get("timestamp", 0) < UPDATE_CHECK_TTL
+            and _cache_age(cached) < UPDATE_CHECK_TTL
             and cached.get("local") == local[:8]):
         return cached.get("update_available", False)
 
@@ -1749,6 +1763,13 @@ def read_cache(cache_path, ttl):
     try:
         with open(cache_path, "r", encoding="utf-8") as f:
             cached = json.load(f)
+        # The file is ours, but it is still untrusted input: a truncated write,
+        # a disk error, or a hand-edit can leave valid JSON of the wrong shape.
+        # Anything other than a dict is treated as a cache miss rather than
+        # allowed to raise — read_cache sits on the hot path, so an exception
+        # here blanks the status bar.
+        if not isinstance(cached, dict):
+            return None
         # An active 429 backoff wins over the normal TTL: keep serving what we
         # have until the backoff expires. Without this, a rate-limited session
         # that still had usable cached usage re-hit the API on every refresh —
@@ -1766,9 +1787,13 @@ def read_cache(cache_path, ttl):
             effective_ttl = _RATE_LIMIT_CACHE_TTL
         else:
             effective_ttl = _ERROR_CACHE_TTL
-        if time.time() - cached.get("timestamp", 0) < effective_ttl:
+        try:
+            age = time.time() - float(cached.get("timestamp", 0) or 0)
+        except (TypeError, ValueError):
+            return None  # unusable timestamp — treat as a miss
+        if age < effective_ttl:
             return cached
-    except (FileNotFoundError, json.JSONDecodeError, KeyError):
+    except (FileNotFoundError, json.JSONDecodeError, KeyError, OSError):
         pass
     return None
 
@@ -1806,7 +1831,9 @@ def write_cache(cache_path, line, usage=None, plan=None,
     """
     try:
         data = {"timestamp": time.time(), "line": line}
-        if usage is not None:
+        # `usage` can arrive from a stale cache file (the 429 fallback path
+        # re-writes what it just read), so it is not guaranteed to be a dict.
+        if isinstance(usage, dict):
             data["usage"] = {k: v for k, v in usage.items() if k in _USAGE_CACHE_KEYS}
         if plan is not None:
             data["plan"] = plan
@@ -2015,9 +2042,10 @@ def _normalize_usage(usage):
         if not name:
             continue
         # "Fable" → seven_day_fable; "Sonnet 4.6" → seven_day_sonnet_4_6
-        key = "seven_day_" + re.sub(r"[^a-z0-9]+", "_", str(name).lower()).strip("_")
-        if not key.strip("_"):
-            continue
+        slug = re.sub(r"[^a-z0-9]+", "_", str(name).lower()).strip("_")
+        if not slug:
+            continue  # e.g. display_name "!!!" — would yield a bare "seven_day_"
+        key = "seven_day_" + slug
         existing = usage.get(key)
         if isinstance(existing, dict) and existing.get("utilization") is not None:
             continue
@@ -3377,8 +3405,15 @@ def _parse_stdin_context(raw_stdin):
                 if isinstance(k, str) and k.startswith("seven_day_")
             )
             for window in windows:
-                w = rl.get(window)
-                if isinstance(w, dict) and w.get("used_percentage") is not None:
+                # Guard each window separately. Sharing one try/except across
+                # the loop meant a single unparseable `used_percentage` aborted
+                # it and silently dropped every window after the bad one — the
+                # weekly and per-model bars would vanish because of one field.
+                try:
+                    w = rl.get(window)
+                    if not isinstance(w, dict) or w.get("used_percentage") is None:
+                        continue
+                    utilization = float(w["used_percentage"])
                     # Convert Unix epoch seconds to ISO string for compatibility
                     # with existing format_reset_time / format_weekly_reset
                     resets_at = w.get("resets_at")
@@ -3388,12 +3423,14 @@ def _parse_stdin_context(raw_stdin):
                             resets_iso = datetime.fromtimestamp(
                                 float(resets_at), tz=timezone.utc
                             ).isoformat()
-                        except (ValueError, OSError):
+                        except (ValueError, OSError, OverflowError, TypeError):
                             pass
                     result["_rate_limits"][window] = {
-                        "utilization": float(w["used_percentage"]),
+                        "utilization": utilization,
                         "resets_at": resets_iso,
                     }
+                except (AttributeError, KeyError, TypeError, ValueError):
+                    continue
     except (AttributeError, KeyError, ValueError, TypeError):
         pass
 
@@ -4422,11 +4459,20 @@ def _skip_escape(text, i):
                 return j + 2
             j += 1
         return n
-    # CSI (or a bare ESC followed by a final byte).
-    j = i + 1
-    while j < n and j < i + 25 and text[j] not in _CSI_TERMINATORS:
-        j += 1
-    return j + 1 if j < n else j
+    if i + 1 < n and text[i + 1] == "[":
+        # CSI, per ECMA-48: parameter bytes 0x30-0x3F, then intermediate bytes
+        # 0x20-0x2F, then one final byte 0x40-0x7E. Matching the grammar rather
+        # than a hand-listed set of finals means a long true-colour SGR such as
+        # ESC[38;2;255;128;64;48;2;0;0;0m is consumed whole; the previous
+        # scanner gave up after 25 bytes and counted the tail as visible width.
+        j = i + 2
+        while j < n and 0x30 <= ord(text[j]) <= 0x3F:
+            j += 1
+        while j < n and 0x20 <= ord(text[j]) <= 0x2F:
+            j += 1
+        return j + 1 if j < n else n
+    # Bare ESC followed by a single final byte (e.g. ESC c), or a trailing ESC.
+    return min(i + 2, n)
 
 
 def _osc8(url, label):
@@ -4643,6 +4689,8 @@ def sync_status_line_refresh(config=None):
             settings = json.load(f)
     except (FileNotFoundError, json.JSONDecodeError, OSError):
         return False
+    if not isinstance(settings, dict):
+        return False  # valid JSON, wrong shape — leave it alone
     status_line = settings.get("statusLine")
     if not isinstance(status_line, dict):
         return False

--- a/claude_status.py
+++ b/claude_status.py
@@ -447,9 +447,39 @@ WIDGET_PRIORITY = {
 }
 
 # Reasoning-effort display. Claude Code reports low|medium|high|xhigh|max.
+# Three renderings, because "med" reads as cryptic to anyone who hasn't
+# memorised the abbreviations, while the full word costs width on a busy bar.
 EFFORT_SHORT = {
     "low": "lo", "medium": "med", "high": "hi", "xhigh": "xh", "max": "max",
 }
+EFFORT_FULL = {
+    "low": "Low", "medium": "Medium", "high": "High",
+    "xhigh": "XHigh", "max": "Max",
+}
+EFFORT_FORMATS = ("short", "full", "labeled")
+# Default to the labelled form: "med" is only legible if you already know the
+# abbreviations, and even "Medium" on its own is ambiguous next to a model name.
+DEFAULT_EFFORT_FORMAT = "labeled"
+
+
+def _format_effort(level, effort_format=DEFAULT_EFFORT_FORMAT):
+    """Render a reasoning-effort level per the user's ``effort_format``.
+
+    short   → ``med``
+    full    → ``Medium``
+    labeled → ``Effort: Medium``  (default; unambiguous at a glance)
+
+    An unrecognised level is passed through rather than dropped — a new effort
+    tier should still show up, just without a prettier name.
+    """
+    if not level:
+        return ""
+    if effort_format not in EFFORT_FORMATS:
+        effort_format = DEFAULT_EFFORT_FORMAT
+    if effort_format == "short":
+        return EFFORT_SHORT.get(level, level)
+    full = EFFORT_FULL.get(level, level.title())
+    return f"Effort: {full}" if effort_format == "labeled" else full
 
 # Higher effort burns limits faster, so escalate the colour with it.
 EFFORT_COLOURS = {
@@ -1006,6 +1036,7 @@ def load_config():
     data.setdefault("bar_style", DEFAULT_BAR_STYLE)
     data.setdefault("layout", DEFAULT_LAYOUT)
     data.setdefault("context_format", "percent")
+    data.setdefault("effort_format", DEFAULT_EFFORT_FORMAT)
     data.setdefault("extra_display", "auto")
     if "currency" not in data:
         data["currency"] = _detect_default_currency()
@@ -4282,7 +4313,9 @@ def build_status_line(usage, plan, config=None, stdin_ctx=None, cache_age=None):
         effort = (stdin_ctx or {}).get("effort") or os.environ.get("CLAUDE_CODE_EFFORT_LEVEL", "")
         if effort and effort != "unset":
             effort = _sanitize(effort)
-            effort_short = EFFORT_SHORT.get(effort, effort)
+            effort_short = _format_effort(
+                effort, config.get("effort_format", DEFAULT_EFFORT_FORMAT)
+            )
             colour = EFFORT_COLOURS.get(effort, "")
             parts.append((_pri("effort"), f"{colour}{effort_short}{RESET}" if colour else effort_short))
 
@@ -5855,6 +5888,26 @@ def main():
             utf8_print(f"Animation speed: {BOLD}{val}{RESET}  ({ANIMATION_SPEEDS[val]}x)")
         else:
             utf8_print("Usage: --animation-speed <slow|normal|fast>")
+        return
+
+    if "--effort-format" in args:
+        idx = args.index("--effort-format")
+        if idx + 1 < len(args):
+            val = args[idx + 1].lower()
+            if val in EFFORT_FORMATS:
+                config = load_config()
+                config["effort_format"] = val
+                save_config(config)
+                sample = _format_effort("medium", val)
+                utf8_print(f"Effort format: {BOLD}{val}{RESET}  (renders as: {sample})")
+            else:
+                utf8_print(f"Usage: --effort-format <{'|'.join(EFFORT_FORMATS)}>")
+                for fmt in EFFORT_FORMATS:
+                    utf8_print(f"  {fmt:<10} {_format_effort('medium', fmt)}")
+        else:
+            config = load_config()
+            current = config.get("effort_format", DEFAULT_EFFORT_FORMAT)
+            utf8_print(f"Effort format: {BOLD}{current}{RESET}  (renders as: {_format_effort('medium', current)})")
         return
 
     if "--config" in args:

--- a/commands/pulse.md
+++ b/commands/pulse.md
@@ -74,6 +74,10 @@ If $ARGUMENTS matches `focus start [minutes]` or `focus stop` or `focus status`:
 -> Run `--focus <action> [minutes]` directly.
 -> Default is 25 minutes if no duration given.
 
+If $ARGUMENTS matches `effort-format <value>`:
+-> Run `--effort-format <value>` directly.
+-> Values: `labeled` (default, "Effort: Medium"), `full` ("Medium"), `short` ("med")
+
 If $ARGUMENTS matches `clock <format>` (where format is `12h` or `24h`):
 -> Run `--clock-format <format>` directly.
 

--- a/commands/pulse.md
+++ b/commands/pulse.md
@@ -1,4 +1,4 @@
-Configure your Claude status bars — themes, colours, animations, peak hours, and more. $ARGUMENTS
+Configure your Claude status bars — themes, colours, animations, widgets, and more. $ARGUMENTS
 
 ---
 
@@ -66,10 +66,6 @@ If $ARGUMENTS matches `bar-style <name>` or `style <name>`:
 
 If $ARGUMENTS matches `layout <name>`:
 -> Run `--layout <name>` directly.
-
-If $ARGUMENTS matches `peak-hours <value>` or `peak <value>`:
--> Run `--peak-hours <value>` directly.
--> Examples: `peak-hours 13:00-19:00`, `peak-hours off`, `peak-hours on`
 
 If $ARGUMENTS matches `animation-speed <speed>` or `speed <speed>`:
 -> Run `--animation-speed <speed>` directly.
@@ -198,21 +194,7 @@ Options:
 
 Apply with `--currency <symbol>`. Explain: the cost shows what this session would cost at API rates, converted to their currency via live exchange rate.
 
-**Step 7:** Peak hours:
-
-```
-Question: "Enable peak hours indicator? (Anthropic's 2x consumption window)"
-Options:
-  - "On — 1pm-7pm (Recommended)" — "Default window matching known peak times"
-  - "Custom" — "Set your own peak window"
-  - "Off" — "Don't show peak indicator"
-```
-
-If "Custom", ask for start and end time (HH:MM format). Apply with `--peak-hours <start>-<end>`.
-If "On", apply `--peak-hours on`.
-If "Off", apply `--peak-hours off`.
-
-**Step 8:** Clock format:
+**Step 7:** Clock format:
 
 ```
 Question: "Clock format for timers?"
@@ -223,7 +205,7 @@ Options:
 
 Apply with `--clock-format <12h|24h>`.
 
-**Step 9:** Live heartbeat hook:
+**Step 8:** Live heartbeat hook:
 
 ```
 Question: "Install the live heartbeat hook? (shows tool counter during active work)"
@@ -234,8 +216,8 @@ Options:
 
 If "Yes", run `python "SCRIPT_PATH" --install-hooks`. Remind to restart Claude Code.
 
-**Step 10:** Confirm everything:
-"All set! Your status bar is configured with **<theme>**, **<animation>** animation, **<currency>** cost tracking, and peak hours **<on/off>**. It updates on every interaction."
+**Step 9:** Confirm everything:
+"All set! Your status bar is configured with **<theme>**, **<animation>** animation, and **<currency>** cost tracking. It updates on every interaction."
 
 If hooks were installed: "Restart Claude Code to activate the live heartbeat."
 

--- a/config.json
+++ b/config.json
@@ -9,6 +9,7 @@
   "layout": "standard",
   "max_width": 80,
   "context_format": "percent",
+  "effort_format": "labeled",
   "weekly_timer_format": "auto",
   "clock_format": "12h",
   "extra_display": "auto",

--- a/config.json
+++ b/config.json
@@ -13,12 +13,6 @@
   "clock_format": "12h",
   "extra_display": "auto",
   "currency": "$",
-  "peak_hours": {
-    "enabled": true,
-    "start": "13:00",
-    "end": "19:00",
-    "weekdays_only": true
-  },
   "show": {
     "session": true,
     "weekly": true,
@@ -50,6 +44,15 @@
     "streak": false,
     "pace": false,
     "git_drift": false,
-    "files_changed": false
+    "files_changed": false,
+    "fable": true,
+    "fast_mode": true,
+    "thinking": false,
+    "agent": true,
+    "cumulative_cost": false,
+    "weekly_cost": false,
+    "cache": false,
+    "pr": false,
+    "lines": true
   }
 }

--- a/generate_gif.py
+++ b/generate_gif.py
@@ -554,14 +554,14 @@ def main():
         for session_pct, weekly_pct, ctx_pct, reset, desc, eu, el in scenarios:
             frames_data.append((
                 theme_name, theme, session_pct, weekly_pct, ctx_pct,
-                reset, "Max 20x", "Opus 4.6", desc, False, 0, eu, el
+                reset, "Max 20x", "Opus 5", desc, False, 0, eu, el
             ))
 
     rainbow_theme = THEME_CSS["rainbow"]
     for offset in range(10):
         frames_data.append((
             "rainbow", rainbow_theme, 55, 38, 45,
-            "2h 10m", "Max 20x", "Opus 4.6", "animated shimmer", True, offset,
+            "2h 10m", "Max 20x", "Opus 5", "animated shimmer", True, offset,
             "£18.50", "£37.00"
         ))
 
@@ -603,13 +603,13 @@ def main():
         theme = THEME_CSS[tname]
         for sp, wp, cp, reset, desc in update_scenarios:
             update_frames.append((tname, theme, sp, wp, cp, reset,
-                                  "Max 20x", "Opus 4.6", desc, False, 0))
+                                  "Max 20x", "Opus 5", desc, False, 0))
 
     # Rainbow shimmer for update GIF too
     for offset in range(10):
         update_frames.append((
             "rainbow", THEME_CSS["rainbow"], 55, 38, 45,
-            "2h 10m", "Max 20x", "Opus 4.6", "shimmer", True, offset
+            "2h 10m", "Max 20x", "Opus 5", "shimmer", True, offset
         ))
 
     tmp_dir2 = Path(tempfile.mkdtemp())
@@ -648,13 +648,13 @@ def main():
         theme = THEME_CSS[tname]
         for sp, wp, cp, reset, desc in cc_update_scenarios:
             cc_update_frames.append((tname, theme, sp, wp, cp, reset,
-                                     "Max 20x", "Opus 4.6", desc, False, 0))
+                                     "Max 20x", "Opus 5", desc, False, 0))
 
     # Rainbow shimmer for claude update GIF too
     for offset in range(10):
         cc_update_frames.append((
             "rainbow", THEME_CSS["rainbow"], 55, 38, 45,
-            "2h 10m", "Max 20x", "Opus 4.6", "shimmer", True, offset
+            "2h 10m", "Max 20x", "Opus 5", "shimmer", True, offset
         ))
 
     tmp_dir3 = Path(tempfile.mkdtemp())

--- a/pulse.md
+++ b/pulse.md
@@ -74,6 +74,10 @@ If $ARGUMENTS matches `focus start [minutes]` or `focus stop` or `focus status`:
 -> Run `--focus <action> [minutes]` directly.
 -> Default is 25 minutes if no duration given.
 
+If $ARGUMENTS matches `effort-format <value>`:
+-> Run `--effort-format <value>` directly.
+-> Values: `labeled` (default, "Effort: Medium"), `full` ("Medium"), `short` ("med")
+
 If $ARGUMENTS matches `clock <format>` (where format is `12h` or `24h`):
 -> Run `--clock-format <format>` directly.
 

--- a/pulse.md
+++ b/pulse.md
@@ -1,4 +1,4 @@
-Configure your Claude status bars — themes, colours, animations, peak hours, and more. $ARGUMENTS
+Configure your Claude status bars — themes, colours, animations, widgets, and more. $ARGUMENTS
 
 ---
 
@@ -66,10 +66,6 @@ If $ARGUMENTS matches `bar-style <name>` or `style <name>`:
 
 If $ARGUMENTS matches `layout <name>`:
 -> Run `--layout <name>` directly.
-
-If $ARGUMENTS matches `peak-hours <value>` or `peak <value>`:
--> Run `--peak-hours <value>` directly.
--> Examples: `peak-hours 13:00-19:00`, `peak-hours off`, `peak-hours on`
 
 If $ARGUMENTS matches `animation-speed <speed>` or `speed <speed>`:
 -> Run `--animation-speed <speed>` directly.
@@ -198,21 +194,7 @@ Options:
 
 Apply with `--currency <symbol>`. Explain: the cost shows what this session would cost at API rates, converted to their currency via live exchange rate.
 
-**Step 7:** Peak hours:
-
-```
-Question: "Enable peak hours indicator? (Anthropic's 2x consumption window)"
-Options:
-  - "On — 1pm-7pm (Recommended)" — "Default window matching known peak times"
-  - "Custom" — "Set your own peak window"
-  - "Off" — "Don't show peak indicator"
-```
-
-If "Custom", ask for start and end time (HH:MM format). Apply with `--peak-hours <start>-<end>`.
-If "On", apply `--peak-hours on`.
-If "Off", apply `--peak-hours off`.
-
-**Step 8:** Clock format:
+**Step 7:** Clock format:
 
 ```
 Question: "Clock format for timers?"
@@ -223,7 +205,7 @@ Options:
 
 Apply with `--clock-format <12h|24h>`.
 
-**Step 9:** Live heartbeat hook:
+**Step 8:** Live heartbeat hook:
 
 ```
 Question: "Install the live heartbeat hook? (shows tool counter during active work)"
@@ -234,8 +216,8 @@ Options:
 
 If "Yes", run `python "SCRIPT_PATH" --install-hooks`. Remind to restart Claude Code.
 
-**Step 10:** Confirm everything:
-"All set! Your status bar is configured with **<theme>**, **<animation>** animation, **<currency>** cost tracking, and peak hours **<on/off>**. It updates on every interaction."
+**Step 9:** Confirm everything:
+"All set! Your status bar is configured with **<theme>**, **<animation>** animation, and **<currency>** cost tracking. It updates on every interaction."
 
 If hooks were installed: "Restart Claude Code to activate the live heartbeat."
 

--- a/tests/test_calculate_streak.py
+++ b/tests/test_calculate_streak.py
@@ -1,0 +1,99 @@
+"""Tests for the daily-usage streak calculator (``_calculate_streak``).
+
+The stats view shows a "current" and "longest" streak of consecutive days on
+which Claude was used.  The function is pure — it takes a list of ``YYYY-MM-DD``
+strings plus a "today" string and returns ``(current, longest)`` — so it can be
+exercised without touching the filesystem or the clock.
+
+Cases pinned here:
+
+* the empty / all-garbage inputs return ``(0, 0)`` instead of raising;
+* the current streak counts back from *today*, and also from *yesterday* when
+  today has not been logged yet (so an active streak isn't dropped mid-day);
+* a gap breaks the current streak but the longest run is still reported;
+* duplicate and unsorted dates are deduplicated and ordered first;
+* an unparseable ``today`` is handled, and stray bad entries are skipped.
+
+Run: ``python tests/test_calculate_streak.py``
+"""
+import sys
+import unittest
+from datetime import date, timedelta
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import claude_status as cs  # noqa: E402
+
+
+def _days(anchor, offsets):
+    """Return ``YYYY-MM-DD`` strings ``offsets`` days before ``anchor``."""
+    return [(anchor - timedelta(days=n)).strftime("%Y-%m-%d") for n in offsets]
+
+
+class CalculateStreakTest(unittest.TestCase):
+    def setUp(self):
+        self.today = date(2026, 7, 17)
+        self.today_str = self.today.strftime("%Y-%m-%d")
+
+    def test_empty_input_is_zero_zero(self):
+        self.assertEqual(cs._calculate_streak([], self.today_str), (0, 0))
+
+    def test_all_unparseable_dates_is_zero_zero(self):
+        self.assertEqual(
+            cs._calculate_streak(["not-a-date", "2026-13-99"], self.today_str),
+            (0, 0),
+        )
+
+    def test_bad_today_is_zero_zero(self):
+        # A valid history but a garbage "today" cannot anchor a current streak.
+        self.assertEqual(
+            cs._calculate_streak(_days(self.today, [0, 1, 2]), "garbage"),
+            (0, 0),
+        )
+
+    def test_streak_ending_today(self):
+        # today, yesterday, day-before => 3 consecutive ending on today.
+        dates = _days(self.today, [0, 1, 2])
+        self.assertEqual(cs._calculate_streak(dates, self.today_str), (3, 3))
+
+    def test_streak_ending_yesterday_when_today_not_logged(self):
+        # Today isn't in the list yet; a run ending yesterday still counts as
+        # the current streak so an active streak isn't lost before you log today.
+        # Regression: the fallback compared against `check_ord + 1` (tomorrow),
+        # so it never matched and an active streak read as 0 all morning.
+        dates = _days(self.today, [1, 2, 3])
+        self.assertEqual(cs._calculate_streak(dates, self.today_str), (3, 3))
+
+    def test_gap_breaks_current_but_longest_survives(self):
+        # A 4-day run two weeks ago, then today alone.
+        old = _days(self.today, [10, 11, 12, 13])
+        dates = old + _days(self.today, [0])
+        current, longest = cs._calculate_streak(dates, self.today_str)
+        self.assertEqual(current, 1, "only today is current after the gap")
+        self.assertEqual(longest, 4, "the old 4-day run is the longest")
+
+    def test_stale_history_has_no_current_streak(self):
+        # Newest entry is two days before today (not today, not yesterday).
+        dates = _days(self.today, [2, 3, 4])
+        current, longest = cs._calculate_streak(dates, self.today_str)
+        self.assertEqual(current, 0, "nothing logged today or yesterday")
+        self.assertEqual(longest, 3)
+
+    def test_duplicates_and_unsorted_are_normalised(self):
+        dates = _days(self.today, [1, 0, 2, 1, 0])  # shuffled + repeats
+        self.assertEqual(cs._calculate_streak(dates, self.today_str), (3, 3))
+
+    def test_single_day_today(self):
+        self.assertEqual(
+            cs._calculate_streak([self.today_str], self.today_str), (1, 1)
+        )
+
+    def test_mixed_valid_and_garbage_entries(self):
+        dates = _days(self.today, [0, 1]) + ["oops", "2026-99-99"]
+        self.assertEqual(cs._calculate_streak(dates, self.today_str), (2, 2))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_readme_claims.py
+++ b/tests/test_readme_claims.py
@@ -1,0 +1,115 @@
+"""Guard the README's factual claims against drift from the source.
+
+The README is the project's shop window, and a claim that quietly drifted away
+from the code is worse than no claim at all. Everything machine-checkable is
+asserted here: theme/style/animation counts, that every documented --show/--hide
+flag is a real widget, that the example status line has no removed segments,
+that no removed feature is still advertised, and that every local asset exists.
+
+Run: ``python tests/test_readme_claims.py``
+
+The README is the project's shop window; a claim that drifted from the code is
+worse than no claim. This checks the ones that are machine-verifiable.
+"""
+import re
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO))
+import claude_status as cs  # noqa: E402
+
+try:
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+except Exception:
+    pass
+
+readme = (REPO / "README.md").read_text(encoding="utf-8")
+issues = []
+
+
+def check(name, ok, detail=""):
+    print(f"  {'ok  ' if ok else 'FAIL'}  {name}" + (f"  — {detail}" if detail else ""))
+    if not ok:
+        issues.append(f"{name}: {detail}")
+
+
+print("== version / floor ==")
+check("VERSION is 3.2.0", cs.VERSION == "3.2.0", cs.VERSION)
+# "3.6+" may legitimately appear in a historical note about 3.1.0; what must
+# not appear is 3.6 stated as the *current* requirement.
+stale_floor = re.search(r"(?:Python|python)[- ]3\.6\+(?!.*advertised)", readme)     and "advertised 3.6+" not in readme
+check("README states Python 3.8+ as the requirement", "3.8+" in readme and not stale_floor)
+
+print("\n== themes ==")
+themes = set(cs.THEMES) if hasattr(cs, "THEMES") else set(cs.THEME_COLOURS)
+claimed = re.search(r"\*\*(\d+) themes\*\*", readme)
+check("theme count claim matches code",
+      claimed and int(claimed.group(1)) == len(themes),
+      f"README says {claimed.group(1) if claimed else '?'}, code has {len(themes)}: {sorted(themes)}")
+for t in sorted(themes):
+    check(f"theme '{t}' documented", t in readme)
+
+print("\n== bar styles ==")
+styles = set(cs.BAR_STYLES)
+claimed_bs = re.search(r"\*\*(\d+) bar styles\*\*", readme)
+check("bar style count matches",
+      claimed_bs and int(claimed_bs.group(1)) == len(styles),
+      f"README says {claimed_bs.group(1) if claimed_bs else '?'}, code has {len(styles)}: {sorted(styles)}")
+for s in sorted(styles):
+    check(f"bar style '{s}' documented", s in readme)
+
+print("\n== animation modes ==")
+modes = set(cs.ANIMATE_MODES)
+if modes:
+    claimed_am = re.search(r"\*\*(\d+) animation modes\*\*", readme)
+    check("animation mode count matches",
+          claimed_am and int(claimed_am.group(1)) == len(modes),
+          f"README says {claimed_am.group(1) if claimed_am else '?'}, code has {len(modes)}: {sorted(modes)}")
+    for m in sorted(modes):
+        check(f"animation '{m}' documented", m in readme)
+
+print("\n== show/hide flags ==")
+flags = set(re.findall(r"--(?:show|hide) (\w+)", readme))
+for f in sorted(flags):
+    check(f"--show/--hide {f} is a real widget", f in cs.DEFAULT_SHOW)
+
+print("\n== layouts / bar sizes ==")
+for size in cs.BAR_SIZES:
+    check(f"bar size '{size}' documented", size in readme)
+
+print("\n== example status line reflects current reality ==")
+example = next((l for l in readme.split("\n") if l.startswith("Session ")), "")
+check("example exists", bool(example))
+check("example has no peak segment", "Peak" not in example, example[:80])
+check("example uses a current model",
+      any(m in example for m in ("Opus 5", "Fable", "Sonnet 5")),
+      example[:120])
+
+print("\n== no removed features referenced ==")
+for gone in ("--peak-hours", "peak_hours", "In Peak", "Off-Peak"):
+    check(f"'{gone}' absent", gone not in readme)
+
+print("\n== removed functions not referenced ==")
+check("_check_peak_hours gone from code", not hasattr(cs, "_check_peak_hours"))
+check("peak not in WIDGET_PRIORITY", "peak" not in cs.WIDGET_PRIORITY)
+
+print("\n== settings key correctness ==")
+check("README documents refreshInterval", "refreshInterval" in readme)
+check("README does not promote the dead 'refresh' key",
+      not re.search(r'"refresh"\s*:', readme))
+
+print("\n== model claims ==")
+for m in ("Fable", "Opus", "Sonnet", "Haiku"):
+    check(f"model family '{m}' mentioned", m in readme)
+
+print("\n== links / assets exist ==")
+for src in re.findall(r'src="([^"]+)"', readme):
+    if src.startswith("http"):
+        continue
+    check(f"asset {src} exists", (REPO / src).exists())
+
+print("\n" + ("README AUDIT CLEAN" if not issues else f"{len(issues)} ISSUE(S):"))
+for i in issues:
+    print("  -", i)
+sys.exit(1 if issues else 0)

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -245,5 +245,42 @@ class CsiGrammarTest(unittest.TestCase):
         self.assertEqual(cs._visible_len("[38;2;255"), 0)
 
 
+class EffortFormatTest(unittest.TestCase):
+    """Effort has three renderings; "med" alone reads as cryptic."""
+
+    def test_short(self):
+        self.assertEqual(cs._format_effort("medium", "short"), "med")
+        self.assertEqual(cs._format_effort("xhigh", "short"), "xh")
+
+    def test_full(self):
+        self.assertEqual(cs._format_effort("medium", "full"), "Medium")
+        self.assertEqual(cs._format_effort("xhigh", "full"), "XHigh")
+
+    def test_labeled_is_the_default(self):
+        self.assertEqual(cs.DEFAULT_EFFORT_FORMAT, "labeled")
+        self.assertEqual(cs._format_effort("medium"), "Effort: Medium")
+        self.assertEqual(cs._format_effort("max"), "Effort: Max")
+
+    def test_every_level_renders_in_every_format(self):
+        for level in ("low", "medium", "high", "xhigh", "max"):
+            for fmt in cs.EFFORT_FORMATS:
+                out = cs._format_effort(level, fmt)
+                self.assertTrue(out, f"{level}/{fmt} rendered empty")
+
+    def test_unknown_level_passes_through(self):
+        """A new effort tier should still appear, just without a nicer name."""
+        self.assertEqual(cs._format_effort("ultra", "short"), "ultra")
+        self.assertEqual(cs._format_effort("ultra", "full"), "Ultra")
+
+    def test_empty_level_renders_nothing(self):
+        for fmt in cs.EFFORT_FORMATS:
+            self.assertEqual(cs._format_effort("", fmt), "")
+            self.assertEqual(cs._format_effort(None, fmt), "")
+
+    def test_invalid_format_falls_back_to_default(self):
+        self.assertEqual(cs._format_effort("medium", "bogus"),
+                         cs._format_effort("medium", cs.DEFAULT_EFFORT_FORMAT))
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -176,5 +176,74 @@ class RateLimitBackoffTest(unittest.TestCase):
             self.assertEqual(fails, 1, f"{bad!r}")
 
 
+class CorruptStateResilienceTest(unittest.TestCase):
+    """Our own state files are still untrusted input.
+
+    A truncated write, a disk error, or a hand-edit can leave *valid JSON of
+    the wrong shape*. These paths run on every repaint, so raising blanks the
+    user's status bar. All found by adversarial review.
+    """
+
+    def test_read_cache_survives_wrong_shaped_json(self):
+        import json
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "c.json"
+            for junk in ("[1, 2]", '"a string"', "42", "null",
+                         '{"timestamp": "bad"}', '{"timestamp": null}'):
+                p.write_text(junk, encoding="utf-8")
+                self.assertIsNone(cs.read_cache(p, 60), junk)
+
+    def test_write_cache_survives_non_dict_usage(self):
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            p = Path(td) / "c.json"
+            for bad in ("not-a-dict", [1, 2], 7, True):
+                cs.write_cache(p, "line", usage=bad)  # must not raise
+
+    def test_sync_refresh_survives_wrong_shaped_settings(self):
+        import os
+        import tempfile
+        with tempfile.TemporaryDirectory() as td:
+            os.environ["CLAUDE_CONFIG_DIR"] = td
+            try:
+                for junk in ("[]", '"x"', "5", "null"):
+                    (Path(td) / "settings.json").write_text(junk, encoding="utf-8")
+                    self.assertIs(cs.sync_status_line_refresh({"animate": "off"}), False, junk)
+            finally:
+                os.environ.pop("CLAUDE_CONFIG_DIR", None)
+
+    def test_cache_age_of_corrupt_entry_is_infinite(self):
+        self.assertEqual(cs._cache_age({"timestamp": "bad"}), float("inf"))
+        self.assertEqual(cs._cache_age([]), float("inf"))
+        self.assertLess(cs._cache_age({"timestamp": __import__("time").time()}), 5)
+
+
+class CsiGrammarTest(unittest.TestCase):
+    """_skip_escape follows the ECMA-48 CSI grammar, not a hand-listed set.
+
+    A long true-colour SGR exceeded the old 25-byte scan cap, so the tail was
+    counted as visible width and the line truncated far too early.
+    """
+
+    def test_long_truecolour_sgr_is_consumed_whole(self):
+        seq = "[38;2;255;128;64;48;2;0;0;0;1;4;7m"
+        self.assertEqual(cs._visible_len(seq + "AB"), 2)
+
+    def test_ordinary_sgr(self):
+        self.assertEqual(cs._visible_len("[0m" + "abc"), 3)
+        self.assertEqual(cs._visible_len("[1;31mX"), 1)
+
+    def test_csi_with_intermediate_bytes(self):
+        self.assertEqual(cs._visible_len("[?25lZ"), 1)
+
+    def test_bare_escape_and_trailing_escape(self):
+        self.assertEqual(cs._visible_len("cQ"), 1)
+        self.assertEqual(cs._visible_len("ab"), 2)
+
+    def test_unterminated_csi_does_not_overrun(self):
+        self.assertEqual(cs._visible_len("[38;2;255"), 0)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_rendering.py
+++ b/tests/test_rendering.py
@@ -1,0 +1,180 @@
+"""Tests for status-line rendering: widths, hyperlinks, and row layout.
+
+The status line writes raw ANSI to a terminal, so the width maths has to be
+exactly right — a miscount either truncates visible text early or lets the line
+spill into Claude Code's notification area.  Three things are pinned here:
+
+* ``_visible_len`` / ``_skip_escape`` count only printable columns, including
+  across OSC 8 hyperlinks (whose URLs contain letters that terminate a *CSI*
+  sequence, so a colour-only scanner walks straight into the URL);
+* ``_osc8`` refuses to linkify anything that could break out of the escape;
+* ``_join_parts`` splits widgets across two rows per ``line1_widgets`` /
+  ``line2_widgets``, and ``_fit_line`` fits each row against its own budget.
+
+Run: ``python tests/test_rendering.py``
+"""
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import claude_status as cs  # noqa: E402
+
+URL = "https://github.com/owner/repo/pull/1234"
+
+
+class VisibleLenTest(unittest.TestCase):
+    def test_plain_text(self):
+        self.assertEqual(cs._visible_len("hello"), 5)
+
+    def test_colour_codes_are_free(self):
+        self.assertEqual(cs._visible_len(f"{cs.GREEN}abc{cs.RESET}"), 3)
+
+    def test_hyperlink_url_is_not_counted(self):
+        """Regression: the CSI terminator set contains 'h', so a naive scanner
+        stopped at the 'h' of 'https' and counted the whole URL as visible."""
+        link = cs._osc8(URL, "#1234")
+        self.assertEqual(cs._visible_len(link), len("#1234"))
+
+    def test_hyperlink_embedded_in_a_line(self):
+        line = f"ab{cs._osc8(URL, '#1')}cd"
+        self.assertEqual(cs._visible_len(line), len("ab#1cd"))
+
+    def test_unterminated_escape_does_not_hang(self):
+        # Consumes the remainder rather than looping forever.
+        self.assertEqual(cs._visible_len("\033]8;;no-terminator"), 0)
+
+    def test_empty(self):
+        self.assertEqual(cs._visible_len(""), 0)
+
+
+class Osc8Test(unittest.TestCase):
+    def test_wraps_label(self):
+        link = cs._osc8(URL, "#1234")
+        self.assertTrue(link.startswith(cs.OSC8_START))
+        self.assertTrue(link.endswith(cs.OSC8_END))
+        self.assertIn("#1234", link)
+
+    def test_no_url_returns_bare_label(self):
+        self.assertEqual(cs._osc8("", "#1"), "#1")
+        self.assertEqual(cs._osc8(None, "#1"), "#1")
+
+    def test_control_characters_are_refused(self):
+        """A URL containing BEL/ESC/newline/; could terminate the escape early
+        and let arbitrary text reach the terminal as a control sequence."""
+        for bad in ("http://x\a", "http://x\033[0m", "http://x\ny", "http://x;y"):
+            self.assertEqual(cs._osc8(bad, "L"), "L", f"{bad!r} must not be linkified")
+
+
+class JoinPartsTest(unittest.TestCase):
+    def _parts(self):
+        return [
+            ((10, "session"), "SESSION"),
+            ((60, "context"), "CONTEXT"),
+            ((110, "model"), "MODEL"),
+            ((170, "branch"), "BRANCH"),
+        ]
+
+    def test_single_row_by_default(self):
+        out = cs._join_parts(self._parts(), {})
+        self.assertNotIn("\n", out)
+        self.assertEqual(out, "SESSION | CONTEXT | MODEL | BRANCH")
+
+    def test_line2_widgets_demotes_named_ids(self):
+        out = cs._join_parts(self._parts(), {"line2_widgets": ["model", "branch"]})
+        self.assertEqual(out.split("\n"), ["SESSION | CONTEXT", "MODEL | BRANCH"])
+
+    def test_line1_widgets_is_an_allowlist(self):
+        out = cs._join_parts(self._parts(), {"line1_widgets": ["session"]})
+        self.assertEqual(out.split("\n"), ["SESSION", "CONTEXT | MODEL | BRANCH"])
+
+    def test_line1_wins_when_both_set(self):
+        out = cs._join_parts(
+            self._parts(),
+            {"line1_widgets": ["session"], "line2_widgets": ["context"]},
+        )
+        self.assertEqual(out.split("\n")[0], "SESSION")
+
+    def test_empty_row_is_dropped_not_blank(self):
+        out = cs._join_parts(self._parts(), {"line2_widgets": ["nothing-matches"]})
+        self.assertNotIn("\n", out)
+
+    def test_all_demoted_yields_one_row(self):
+        ids = ["session", "context", "model", "branch"]
+        out = cs._join_parts(self._parts(), {"line2_widgets": ids})
+        self.assertNotIn("\n", out)
+
+    def test_malformed_config_falls_back_to_one_row(self):
+        for cfg in ({"line2_widgets": "model"}, {"line1_widgets": 7}, None, "nope"):
+            self.assertNotIn("\n", cs._join_parts(self._parts(), cfg))
+
+
+class FitLineTest(unittest.TestCase):
+    def test_each_row_fitted_independently(self):
+        cfg = {"max_width": 100}
+        two = "AAAA | BBBB\nCCCC | DDDD"
+        out = cs._fit_line(two, cfg)
+        self.assertEqual(len(out.split("\n")), 2)
+
+    def test_single_row_unchanged_when_it_fits(self):
+        self.assertNotIn("\n", cs._fit_line("short", {"max_width": 100}))
+
+    def test_truncation_closes_an_open_hyperlink(self):
+        """Cutting inside an OSC 8 link without closing it makes the terminal
+        treat everything after as part of the link target."""
+        long_label = "X" * 400
+        line = cs._osc8(URL, long_label)
+        out = cs._truncate_line(line, {"max_width": 20})
+        self.assertTrue(out.endswith(cs.OSC8_END + cs.RESET) or cs.OSC8_END in out)
+
+
+class RefreshIntervalTest(unittest.TestCase):
+    def test_animation_gets_the_fast_tick(self):
+        self.assertEqual(
+            cs._desired_refresh_interval({"animate": "rainbow"}), cs.REFRESH_ANIMATED
+        )
+
+    def test_time_based_widget_gets_the_slow_tick(self):
+        cfg = {"animate": "off", "show": {"heartbeat": True, "pomodoro": False}}
+        self.assertEqual(cs._desired_refresh_interval(cfg), cs.REFRESH_TIMED)
+
+    def test_static_bar_needs_no_timer(self):
+        cfg = {"animate": "off", "show": {"heartbeat": False, "pomodoro": False}}
+        self.assertIsNone(cs._desired_refresh_interval(cfg))
+
+    def test_garbage_config_is_safe(self):
+        for cfg in (None, "x", 3, []):
+            self.assertIsNone(cs._desired_refresh_interval(cfg))
+
+
+class RateLimitBackoffTest(unittest.TestCase):
+    def test_first_failure_waits_about_a_minute(self):
+        delay, fails = cs._rate_limit_backoff(0)
+        self.assertEqual(fails, 1)
+        self.assertGreaterEqual(delay, cs._RATE_LIMIT_BACKOFF_BASE)
+        self.assertLessEqual(delay, cs._RATE_LIMIT_BACKOFF_BASE + cs._RATE_LIMIT_JITTER)
+
+    def test_backoff_doubles(self):
+        d1, f1 = cs._rate_limit_backoff(0)
+        d2, f2 = cs._rate_limit_backoff(f1)
+        self.assertEqual(f2, 2)
+        self.assertGreaterEqual(d2, 2 * cs._RATE_LIMIT_BACKOFF_BASE)
+
+    def test_capped(self):
+        delay, _ = cs._rate_limit_backoff(50)
+        self.assertLessEqual(delay, cs._RATE_LIMIT_BACKOFF_MAX + cs._RATE_LIMIT_JITTER)
+
+    def test_absurd_count_does_not_build_a_huge_int(self):
+        delay, _ = cs._rate_limit_backoff(10 ** 9)
+        self.assertLessEqual(delay, cs._RATE_LIMIT_BACKOFF_MAX + cs._RATE_LIMIT_JITTER)
+
+    def test_garbage_count_treated_as_first_failure(self):
+        for bad in (None, "x", -5, [], {}):
+            delay, fails = cs._rate_limit_backoff(bad)
+            self.assertEqual(fails, 1, f"{bad!r}")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_stdin_fields.py
+++ b/tests/test_stdin_fields.py
@@ -1,0 +1,170 @@
+"""Tests for the Claude Code stdin payload parser (``_parse_stdin_context``).
+
+The status line is fed a JSON blob on stdin every time Claude Code repaints.
+That payload is the sole source of truth for the model, context window, cost,
+rate limits, and — as of the Claude 5 era — reasoning effort, fast mode,
+thinking state, the active subagent, and PR context.
+
+Two properties matter most and are pinned here:
+
+* every field is read from the shape Claude Code actually documents, including
+  the ``{"data": {...}}`` envelope variant;
+* a malformed, partial, or hostile payload never raises. The status line runs
+  on every keystroke, so an exception here would blank the user's bar.
+
+Run: ``python tests/test_stdin_fields.py``
+"""
+import json
+import sys
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import claude_status as cs  # noqa: E402
+
+
+def parse(payload):
+    return cs._parse_stdin_context(json.dumps(payload))
+
+
+class EffortFastModeThinkingTest(unittest.TestCase):
+    """Effort now comes from stdin, not an env var Claude Code never exported."""
+
+    def test_effort_level_read_from_stdin(self):
+        self.assertEqual(parse({"effort": {"level": "xhigh"}})["effort"], "xhigh")
+
+    def test_effort_unset_is_ignored(self):
+        self.assertNotIn("effort", parse({"effort": {"level": "unset"}}))
+
+    def test_effort_missing_is_absent(self):
+        self.assertNotIn("effort", parse({}))
+
+    def test_effort_wrong_type_does_not_raise(self):
+        self.assertNotIn("effort", parse({"effort": "high"}))
+        self.assertNotIn("effort", parse({"effort": None}))
+
+    def test_fast_mode_only_true_when_true(self):
+        self.assertTrue(parse({"fast_mode": True})["fast_mode"])
+        self.assertNotIn("fast_mode", parse({"fast_mode": False}))
+        self.assertNotIn("fast_mode", parse({}))
+
+    def test_thinking_records_both_states(self):
+        self.assertIs(parse({"thinking": {"enabled": True}})["thinking"], True)
+        self.assertIs(parse({"thinking": {"enabled": False}})["thinking"], False)
+        self.assertNotIn("thinking", parse({"thinking": {}}))
+
+
+class AgentAndPrTest(unittest.TestCase):
+    def test_agent_name(self):
+        self.assertEqual(parse({"agent": {"name": "reviewer"}})["agent_name"], "reviewer")
+
+    def test_agent_missing_or_blank(self):
+        self.assertNotIn("agent_name", parse({"agent": {"name": ""}}))
+        self.assertNotIn("agent_name", parse({}))
+
+    def test_pr_fields(self):
+        ctx = parse({"pr": {
+            "number": 42,
+            "url": "https://github.com/o/r/pull/42",
+            "review_state": "approved",
+        }})
+        self.assertEqual(ctx["pr_number"], 42)
+        self.assertEqual(ctx["pr_url"], "https://github.com/o/r/pull/42")
+        self.assertEqual(ctx["pr_review_state"], "approved")
+
+    def test_pr_rejects_non_http_url(self):
+        """The URL is embedded in an OSC 8 escape — only http(s) may through."""
+        for bad in ("javascript:alert(1)", "file:///etc/passwd", "data:text/html,x"):
+            ctx = parse({"pr": {"number": 1, "url": bad}})
+            self.assertEqual(ctx["pr_number"], 1)
+            self.assertNotIn("pr_url", ctx, f"{bad} must not be linkified")
+
+    def test_pr_without_number_is_ignored(self):
+        self.assertNotIn("pr_number", parse({"pr": {"url": "https://x/y"}}))
+
+
+class CacheEfficiencyTest(unittest.TestCase):
+    def test_cache_hit_pct_over_billable_input(self):
+        ctx = parse({"context_window": {"current_usage": {
+            "input_tokens": 1000,
+            "cache_creation_input_tokens": 1000,
+            "cache_read_input_tokens": 8000,
+        }}})
+        # 8000 / (8000 + 1000 + 1000) == 80%
+        self.assertAlmostEqual(ctx["cache_hit_pct"], 80.0, places=6)
+        self.assertEqual(ctx["cache_read_tokens"], 8000)
+
+    def test_zero_billable_yields_no_ratio(self):
+        ctx = parse({"context_window": {"current_usage": {
+            "input_tokens": 0,
+            "cache_creation_input_tokens": 0,
+            "cache_read_input_tokens": 0,
+        }}})
+        self.assertNotIn("cache_hit_pct", ctx)
+
+    def test_missing_breakdown_is_absent(self):
+        self.assertNotIn("cache_hit_pct", parse({"context_window": {}}))
+
+
+class ModelAndWindowTest(unittest.TestCase):
+    def test_display_name_strips_claude_prefix(self):
+        ctx = parse({"model": {"id": "claude-opus-5", "display_name": "Claude Opus 5"}})
+        self.assertEqual(ctx["model_name"], "Opus 5")
+
+    def test_falls_back_to_id_mapping(self):
+        self.assertEqual(parse({"model": {"id": "claude-fable-5"}})["model_name"], "Fable")
+
+    def test_dated_variant_maps_to_family(self):
+        ctx = parse({"model": {"id": "claude-haiku-4-5-20251001"}})
+        self.assertEqual(ctx["model_name"], "Haiku")
+
+    def test_longest_prefix_wins(self):
+        """"claude-opus-4" must not shadow "claude-opus-4-8"."""
+        self.assertEqual(cs._model_short_name("claude-opus-4-8"), "Opus")
+        self.assertEqual(cs._model_short_name("claude-sonnet-5"), "Sonnet")
+        self.assertIsNone(cs._model_short_name("gpt-4"))
+        self.assertIsNone(cs._model_short_name(""))
+
+    def test_context_window_size_is_trusted_from_stdin(self):
+        ctx = parse({"context_window": {
+            "used_percentage": 10,
+            "total_input_tokens": 100_000,
+            "total_output_tokens": 0,
+            "context_window_size": 1_000_000,
+        }})
+        self.assertEqual(ctx["context_limit"], 1_000_000)
+
+
+class RobustnessTest(unittest.TestCase):
+    """A bad payload must degrade, never raise — an exception blanks the bar."""
+
+    def test_empty_and_blank_input(self):
+        self.assertEqual(cs._parse_stdin_context(""), {})
+        self.assertEqual(cs._parse_stdin_context("   "), {})
+        self.assertEqual(cs._parse_stdin_context(None), {})
+
+    def test_invalid_json(self):
+        self.assertEqual(cs._parse_stdin_context("{not json"), {})
+
+    def test_data_envelope_variant(self):
+        ctx = cs._parse_stdin_context(json.dumps({"data": {"effort": {"level": "max"}}}))
+        self.assertEqual(ctx["effort"], "max")
+
+    def test_hostile_types_do_not_raise(self):
+        payload = {
+            "effort": [], "thinking": 3, "agent": "x", "pr": 7,
+            "fast_mode": "yes", "context_window": None, "cost": [],
+            "model": 1, "worktree": "no", "rate_limits": "none",
+        }
+        # json.dumps then parse — must return a dict, not explode.
+        self.assertIsInstance(cs._parse_stdin_context(json.dumps(payload)), dict)
+
+    def test_json_scalar_payloads(self):
+        for scalar in ("null", "3", '"text"', "[]"):
+            self.assertIsInstance(cs._parse_stdin_context(scalar), dict)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/tests/test_stdin_fields.py
+++ b/tests/test_stdin_fields.py
@@ -211,6 +211,26 @@ class RateLimitWindowsTest(unittest.TestCase):
         ctx = parse({"rate_limits": {"five_hour": {"used_percentage": 5, "resets_at": "junk"}}})
         self.assertEqual(ctx["_rate_limits"]["five_hour"]["utilization"], 5.0)
 
+    def test_one_malformed_window_does_not_drop_the_others(self):
+        """Regression: a shared try/except around the loop meant a single bad
+        `used_percentage` aborted it, silently discarding every window after
+        the poisoned one — the weekly and per-model bars would just vanish."""
+        ctx = parse({"rate_limits": {
+            "five_hour": {"used_percentage": 10, "resets_at": 1900000000},
+            "seven_day": {"used_percentage": "not-a-number"},
+            "seven_day_fable": {"used_percentage": 50, "resets_at": 1900000000},
+            "seven_day_opus": {"used_percentage": 30, "resets_at": 1900000000},
+        }})
+        self.assertEqual(
+            sorted(ctx["_rate_limits"]),
+            ["five_hour", "seven_day_fable", "seven_day_opus"],
+        )
+
+    def test_bad_resets_at_does_not_drop_the_window(self):
+        for bad in ("junk", None, [], {}, float("inf"), 10 ** 30):
+            ctx = parse({"rate_limits": {"five_hour": {"used_percentage": 5, "resets_at": bad}}})
+            self.assertEqual(ctx["_rate_limits"]["five_hour"]["utilization"], 5.0, repr(bad))
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_stdin_fields.py
+++ b/tests/test_stdin_fields.py
@@ -35,25 +35,28 @@ class EffortFastModeThinkingTest(unittest.TestCase):
     def test_effort_level_read_from_stdin(self):
         self.assertEqual(parse({"effort": {"level": "xhigh"}})["effort"], "xhigh")
 
-    def test_effort_unset_is_ignored(self):
-        self.assertNotIn("effort", parse({"effort": {"level": "unset"}}))
+    def test_effort_unset_records_the_off_value(self):
+        # Present-but-None, not absent: absent would mean "unchanged" to the
+        # persistence layer and the previous level would stay pinned.
+        self.assertIsNone(parse({"effort": {"level": "unset"}})["effort"])
 
     def test_effort_missing_is_absent(self):
         self.assertNotIn("effort", parse({}))
 
     def test_effort_wrong_type_does_not_raise(self):
-        self.assertNotIn("effort", parse({"effort": "high"}))
-        self.assertNotIn("effort", parse({"effort": None}))
+        self.assertIsNone(parse({"effort": "high"})["effort"])
+        self.assertIsNone(parse({"effort": None})["effort"])
 
-    def test_fast_mode_only_true_when_true(self):
-        self.assertTrue(parse({"fast_mode": True})["fast_mode"])
-        self.assertNotIn("fast_mode", parse({"fast_mode": False}))
+    def test_fast_mode_records_both_states(self):
+        self.assertIs(parse({"fast_mode": True})["fast_mode"], True)
+        self.assertIs(parse({"fast_mode": False})["fast_mode"], False)
+        # A fragment with no session identity says nothing either way.
         self.assertNotIn("fast_mode", parse({}))
 
     def test_thinking_records_both_states(self):
         self.assertIs(parse({"thinking": {"enabled": True}})["thinking"], True)
         self.assertIs(parse({"thinking": {"enabled": False}})["thinking"], False)
-        self.assertNotIn("thinking", parse({"thinking": {}}))
+        self.assertIsNone(parse({"thinking": {}})["thinking"])
 
 
 class AgentAndPrTest(unittest.TestCase):
@@ -81,8 +84,8 @@ class AgentAndPrTest(unittest.TestCase):
             self.assertEqual(ctx["pr_number"], 1)
             self.assertNotIn("pr_url", ctx, f"{bad} must not be linkified")
 
-    def test_pr_without_number_is_ignored(self):
-        self.assertNotIn("pr_number", parse({"pr": {"url": "https://x/y"}}))
+    def test_pr_without_number_clears_the_badge(self):
+        self.assertIsNone(parse({"pr": {"url": "https://x/y"}})["pr_number"])
 
 
 class CacheEfficiencyTest(unittest.TestCase):
@@ -230,6 +233,57 @@ class RateLimitWindowsTest(unittest.TestCase):
         for bad in ("junk", None, [], {}, float("inf"), 10 ** 30):
             ctx = parse({"rate_limits": {"five_hour": {"used_percentage": 5, "resets_at": bad}}})
             self.assertEqual(ctx["_rate_limits"]["five_hour"]["utilization"], 5.0, repr(bad))
+
+
+class SessionStateClearsTest(unittest.TestCase):
+    """Session-state fields must be able to turn back off.
+
+    Regression: these were recorded only when *on*, and main() persists stdin
+    context across refreshes treating an absent key as "unchanged". So the
+    ⚡fast badge stuck permanently after a single fast-mode turn — it was still
+    displayed with Fast mode switched off in Claude Code. The same applied to
+    effort and the PR badge.
+
+    Both shapes must clear it: the field sent explicitly as false, and the
+    field dropped from the payload entirely.
+    """
+
+    FULL = {"session_id": "s1", "model": {"id": "claude-opus-5"},
+            "workspace": {"current_dir": "."}}
+
+    def test_explicit_false_clears_fast_mode(self):
+        self.assertIs(parse({**self.FULL, "fast_mode": True})["fast_mode"], True)
+        self.assertIs(parse({**self.FULL, "fast_mode": False})["fast_mode"], False)
+
+    def test_omitted_field_clears_on_a_full_payload(self):
+        self.assertIs(parse(self.FULL)["fast_mode"], False)
+        self.assertIsNone(parse(self.FULL)["effort"])
+        self.assertIsNone(parse(self.FULL)["pr_number"])
+        self.assertIsNone(parse(self.FULL)["agent_name"])
+
+    def test_effort_clears(self):
+        self.assertEqual(parse({**self.FULL, "effort": {"level": "max"}})["effort"], "max")
+        self.assertIsNone(parse({**self.FULL, "effort": {"level": "unset"}})["effort"])
+        self.assertIsNone(parse({**self.FULL, "effort": {}})["effort"])
+
+    def test_pr_clears_when_leaving_the_branch(self):
+        on = parse({**self.FULL, "pr": {"number": 7, "url": "https://x/y", "review_state": "approved"}})
+        self.assertEqual(on["pr_number"], 7)
+        off = parse({**self.FULL, "pr": None})
+        self.assertIsNone(off["pr_number"])
+        self.assertIsNone(off["pr_url"])
+
+    def test_fragment_payload_does_not_clear(self):
+        """A partial payload (no session identity) must not wipe known state —
+        absent there really does mean 'unknown', not 'off'."""
+        frag = parse({"cost": {"total_cost_usd": 1.0}})
+        self.assertNotIn("fast_mode", frag)
+        self.assertNotIn("effort", frag)
+
+    def test_thinking_tri_state(self):
+        self.assertIs(parse({**self.FULL, "thinking": {"enabled": True}})["thinking"], True)
+        self.assertIs(parse({**self.FULL, "thinking": {"enabled": False}})["thinking"], False)
+        self.assertIsNone(parse(self.FULL)["thinking"])
 
 
 if __name__ == "__main__":

--- a/tests/test_stdin_fields.py
+++ b/tests/test_stdin_fields.py
@@ -166,5 +166,51 @@ class RobustnessTest(unittest.TestCase):
             self.assertIsInstance(cs._parse_stdin_context(scalar), dict)
 
 
+class RateLimitWindowsTest(unittest.TestCase):
+    """Every window Claude Code sends must survive into `_rate_limits`.
+
+    Regression: the parser looped over a hardcoded tuple that listed only
+    five_hour / seven_day / _opus / _sonnet, so a Fable weekly cap present on
+    stdin was silently dropped and the bar never appeared.
+    """
+
+    def test_all_model_scoped_windows_are_kept(self):
+        ctx = parse({"rate_limits": {
+            "five_hour": {"used_percentage": 10, "resets_at": 1900000000},
+            "seven_day": {"used_percentage": 20, "resets_at": 1900000000},
+            "seven_day_opus": {"used_percentage": 30, "resets_at": 1900000000},
+            "seven_day_sonnet": {"used_percentage": 40, "resets_at": 1900000000},
+            "seven_day_fable": {"used_percentage": 50, "resets_at": 1900000000},
+        }})
+        self.assertEqual(
+            sorted(ctx["_rate_limits"]),
+            ["five_hour", "seven_day", "seven_day_fable",
+             "seven_day_opus", "seven_day_sonnet"],
+        )
+        self.assertEqual(ctx["_rate_limits"]["seven_day_fable"]["utilization"], 50.0)
+
+    def test_future_model_window_picked_up_without_code_change(self):
+        ctx = parse({"rate_limits": {
+            "seven_day_newmodel": {"used_percentage": 7, "resets_at": 1900000000},
+        }})
+        self.assertIn("seven_day_newmodel", ctx["_rate_limits"])
+
+    def test_epoch_converted_to_iso(self):
+        ctx = parse({"rate_limits": {"five_hour": {"used_percentage": 1, "resets_at": 1900000000}}})
+        self.assertTrue(ctx["_rate_limits"]["five_hour"]["resets_at"].startswith("20"))
+
+    def test_missing_percentage_skipped(self):
+        ctx = parse({"rate_limits": {"five_hour": {"resets_at": 1900000000}}})
+        self.assertNotIn("five_hour", ctx.get("_rate_limits", {}))
+
+    def test_non_dict_window_skipped(self):
+        ctx = parse({"rate_limits": {"seven_day_x": "nope", "five_hour": {"used_percentage": 1}}})
+        self.assertNotIn("seven_day_x", ctx.get("_rate_limits", {}))
+
+    def test_bad_resets_at_keeps_the_window(self):
+        ctx = parse({"rate_limits": {"five_hour": {"used_percentage": 5, "resets_at": "junk"}}})
+        self.assertEqual(ctx["_rate_limits"]["five_hour"]["utilization"], 5.0)
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/tests/test_usage_and_config.py
+++ b/tests/test_usage_and_config.py
@@ -1,0 +1,172 @@
+"""Tests for usage normalisation, config-dir resolution, and pricing lookup.
+
+Three separate concerns, all of which decide what numbers the user sees:
+
+* ``_normalize_usage`` folds the OAuth payload's model-scoped ``limits[]``
+  entries (how Fable's weekly cap is reported) into flat ``seven_day_<model>``
+  keys the renderer already understands;
+* ``_claude_config_dir`` honours ``CLAUDE_CONFIG_DIR`` so a multi-profile setup
+  doesn't get its status line registered in one directory and its ``/pulse``
+  command in another;
+* pricing lookup resolves the *longest* matching model prefix — a first-match
+  scan lets the bare ``claude-opus-4`` key ($15/$75) swallow ``claude-opus-4-8``
+  ($5/$25) and treble every reported cost.
+
+Run: ``python tests/test_usage_and_config.py``
+"""
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT))
+
+import claude_status as cs  # noqa: E402
+
+
+class NormalizeUsageTest(unittest.TestCase):
+    def test_weekly_scoped_becomes_seven_day_key(self):
+        usage = cs._normalize_usage({"limits": [{
+            "kind": "weekly_scoped",
+            "percent": 82,
+            "resets_at": "2026-08-01T00:00:00Z",
+            "scope": {"model": {"display_name": "Fable"}},
+        }]})
+        self.assertEqual(usage["seven_day_fable"]["utilization"], 82.0)
+        self.assertEqual(usage["seven_day_fable"]["resets_at"], "2026-08-01T00:00:00Z")
+
+    def test_display_name_is_slugified(self):
+        usage = cs._normalize_usage({"limits": [{
+            "kind": "weekly_scoped", "percent": 5,
+            "scope": {"model": {"display_name": "Sonnet 4.6"}},
+        }]})
+        self.assertIn("seven_day_sonnet_4_6", usage)
+
+    def test_falls_back_to_model_id(self):
+        usage = cs._normalize_usage({"limits": [{
+            "kind": "weekly_scoped", "percent": 5,
+            "scope": {"model": {"id": "claude-fable-5"}},
+        }]})
+        self.assertIn("seven_day_claude_fable_5", usage)
+
+    def test_existing_flat_field_wins(self):
+        """A top-level field that already has data must not be overwritten."""
+        usage = cs._normalize_usage({
+            "seven_day_fable": {"utilization": 10.0},
+            "limits": [{
+                "kind": "weekly_scoped", "percent": 99,
+                "scope": {"model": {"display_name": "Fable"}},
+            }],
+        })
+        self.assertEqual(usage["seven_day_fable"]["utilization"], 10.0)
+
+    def test_other_kinds_ignored(self):
+        usage = cs._normalize_usage({"limits": [
+            {"kind": "five_hour", "percent": 50,
+             "scope": {"model": {"display_name": "Opus"}}},
+        ]})
+        self.assertNotIn("seven_day_opus", usage)
+
+    def test_missing_percent_skipped(self):
+        usage = cs._normalize_usage({"limits": [{
+            "kind": "weekly_scoped",
+            "scope": {"model": {"display_name": "Fable"}},
+        }]})
+        self.assertNotIn("seven_day_fable", usage)
+
+    def test_malformed_entries_never_raise(self):
+        payloads = [
+            {"limits": "not-a-list"},
+            {"limits": ["string", 7, None, {}]},
+            {"limits": [{"kind": "weekly_scoped", "percent": "abc",
+                         "scope": {"model": {"display_name": "X"}}}]},
+            {"limits": [{"kind": "weekly_scoped", "percent": 1, "scope": None}]},
+            {"limits": [{"kind": "weekly_scoped", "percent": 1,
+                         "scope": {"model": "not-a-dict"}}]},
+            {"limits": [{"kind": "weekly_scoped", "percent": 1,
+                         "scope": {"model": {"display_name": "!!!"}}}]},
+            {},
+            "not-a-dict",
+            None,
+        ]
+        for payload in payloads:
+            cs._normalize_usage(payload)  # must not raise
+
+    def test_no_limits_returns_input_unchanged(self):
+        self.assertEqual(cs._normalize_usage({"a": 1}), {"a": 1})
+
+
+class ClaudeConfigDirTest(unittest.TestCase):
+    def test_defaults_to_home_dot_claude(self):
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("CLAUDE_CONFIG_DIR", None)
+            self.assertEqual(cs._claude_config_dir(), Path.home() / ".claude")
+
+    def test_honours_env_var(self):
+        with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(Path("/tmp/profile-a"))}):
+            self.assertEqual(cs._claude_config_dir(), Path("/tmp/profile-a"))
+
+    def test_blank_value_treated_as_unset(self):
+        """Path("") resolves to the process cwd — never what the user meant."""
+        for blank in ("", "   ", "\t"):
+            with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": blank}):
+                self.assertEqual(cs._claude_config_dir(), Path.home() / ".claude")
+
+
+class PricingLookupTest(unittest.TestCase):
+    def _resolve(self, model_id):
+        """Mirror the longest-prefix resolution used by the cost scanner."""
+        pricing = cs.API_PRICING.get(model_id)
+        if pricing is None:
+            best = None
+            for key in cs.API_PRICING:
+                if model_id.startswith(key) and (best is None or len(key) > len(best)):
+                    best = key
+            pricing = cs.API_PRICING[best] if best else None
+        return pricing
+
+    def test_opus_4_8_is_not_shadowed_by_opus_4(self):
+        self.assertEqual(self._resolve("claude-opus-4-8")["input"], 5.0)
+        self.assertEqual(self._resolve("claude-opus-4-8-20260101")["input"], 5.0)
+
+    def test_legacy_opus_4_keeps_old_pricing(self):
+        self.assertEqual(self._resolve("claude-opus-4")["input"], 15.0)
+
+    def test_current_models_present(self):
+        for model_id in ("claude-fable-5", "claude-opus-5", "claude-sonnet-5"):
+            self.assertIn(model_id, cs.API_PRICING, model_id)
+            self.assertIn(model_id, cs.API_PRICING_DISPLAY, model_id)
+
+    def test_fable_is_priced_above_opus(self):
+        self.assertGreater(
+            cs.API_PRICING["claude-fable-5"]["input"],
+            cs.API_PRICING["claude-opus-5"]["input"],
+        )
+
+    def test_context_windows_reflect_1m_models(self):
+        self.assertEqual(cs.MODEL_CONTEXT_WINDOWS["Opus 5"], 1_000_000)
+        self.assertEqual(cs.MODEL_CONTEXT_WINDOWS["Sonnet 5"], 1_000_000)
+        self.assertEqual(cs.MODEL_CONTEXT_WINDOWS["Haiku 4.5"], 200_000)
+
+
+class TranscriptTimestampTest(unittest.TestCase):
+    def test_z_suffix_parsed(self):
+        """Claude Code writes Z-suffixed stamps; fromisoformat only accepted
+        them from 3.11, and this project supports 3.8."""
+        self.assertIsNotNone(cs._parse_transcript_ts("2026-07-18T15:01:07.532Z"))
+
+    def test_explicit_offset_parsed(self):
+        self.assertIsNotNone(cs._parse_transcript_ts("2026-07-18T15:01:07+00:00"))
+
+    def test_naive_treated_as_utc(self):
+        self.assertIsNotNone(cs._parse_transcript_ts("2026-07-18T15:01:07"))
+
+    def test_garbage_returns_none(self):
+        for bad in ("nope", "", None, 7, [], "2026-13-45T99:99:99Z"):
+            self.assertIsNone(cs._parse_transcript_ts(bad), repr(bad))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
Adds Fable, brings the status line up to date with the current Claude Code stdin schema, removes peak hours, and fixes a set of bugs — the most significant being that **the refresh timer never worked**.

## Fixes

**`statusLine` was written with a `"refresh": 150` key that Claude Code does not have.** It was silently ignored, so the timed repaint never happened: animations, the heartbeat spinner and the focus countdown all froze whenever the session went idle. The real setting is [`refreshInterval`](https://code.claude.com/docs/en/statusline) (seconds). It is now set only when something time-based is actually on screen — 2s while animating, 15s for the heartbeat/focus timer, omitted entirely for a static bar — and re-synced from `save_config()` so a new setting can't forget to.

**Per-model caps arrived on stdin and were thrown away.** `main()` copied only `five_hour` and `seven_day`, then went looking for the model-scoped caps in the cache and, failing that, over OAuth. So Fable never rendered *and* the status line made a network call for data Claude Code had already handed it — contradicting the "zero API calls" design. It now takes every window stdin offers.

**Model tables were badly stale.** No Opus 4.7/4.8/5, Sonnet 5 or Fable; every context window hardcoded to 200K when current models are 1M; Opus priced at $15/$75 instead of $5/$25. Pricing lookup now resolves the *longest* matching prefix — a first-match scan let the bare `claude-opus-4` key shadow `claude-opus-4-8` and treble reported cost.

**Sonnet drew a hardcoded `0%` bar when the API returned `null`** (#46), which reads as a real measurement of an untouched budget. Claude Pro returns `null` for the model-scoped windows, so per-model caps now render only with real data, via one shared code path for Opus/Sonnet/Fable.

**`--install` ignored `CLAUDE_CONFIG_DIR`** (#41), splitting the status line and `/pulse` command across two config dirs.

**A 429 with usable stale data wrote nothing back to cache**, so every refresh retried immediately while still rate-limited. Now persists exponential backoff with jitter.

**The update check false-positived forever on forks** — a fork's commits are never on upstream main, so `local != remote` always held. Now ancestry-based, and suppressed when `origin` isn't upstream.

Also includes the fixes from #38 (backslash in an f-string is a `SyntaxError` before 3.12 — the file could not import on 3.11 despite advertising 3.6+) and #45 (the streak "started yesterday" fallback compared against *tomorrow*, so an active streak read 0 until the first event of the day). Thanks @akizooo3 and @qwart9.

## Performance

Statusline guidance is <50ms per repaint; this was ~204ms.

`claude --version` (~80ms) and `git rev-parse HEAD` (~20ms) both ran on **every repaint**, purely to validate caches with hour-long TTLs. Claude Code reports `version` on stdin, so the subprocess is now a fallback only; the git check is stamped with the script mtime so it runs only when the checkout can have changed.

**Median full invocation: 204ms → 118ms.** The remaining ~70ms is interpreter start plus import.

## Features

- **Fable weekly cap**, folded out of the `weekly_scoped` entries in the OAuth `limits[]` array, so future models are picked up without a code change.
- **New stdin fields**: reasoning effort (previously read from a `CLAUDE_CODE_EFFORT_LEVEL` env var that Claude Code never exported), `fast_mode`, `thinking`, `agent.name`, `pr` as an OSC 8 badge, and a cache-hit ratio from the `current_usage` breakdown.
- **Two-line layout** via `line1_widgets` / `line2_widgets`.
- **Rolling 7-day cost** widget (opt-in).
- **Peak hours removed**, including stale keys left in existing configs.

## Notes

OSC 8 support required making escape-skipping hyperlink-aware: the CSI terminator set contains `h`, so the previous scanner stopped at the `h` in `https` and counted URLs as visible width. `_skip_escape` now follows the ECMA-48 CSI grammar (parameter bytes → intermediate bytes → one final byte), which also fixes long true-colour SGR sequences that exceeded its old 25-byte cap. Truncation closes a hyperlink it cuts through.

A round of adversarial review hardened the state-file reads: a truncated or hand-edited cache/settings file is valid JSON of the wrong shape, and `read_cache`/`write_cache`/`sync_status_line_refresh`/`check_for_update` all raised on it — on the hot path, that blanks the bar. Each now degrades to a cache miss. The rate-limit window loop also shared one `try/except`, so a single unparseable `used_percentage` discarded every window after it.

Verified Python floor is **3.8** (`Path.unlink(missing_ok=True)`); README corrected from 3.6+.

## Tests

21 → 120, covering the streak calculator, stdin field parsing, ANSI/OSC-8 width maths, two-line layout, 429 backoff, usage normalisation and config-dir resolution. Plus fuzzing (10k iterations) over stdin payloads, usage payloads and ANSI soup asserting nothing raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
