### PR TITLE
Fix MiniMax quota fetch on Windows (mmx .cmd shim not resolved)

### DIFF
--- a/claude_status.py
+++ b/claude_status.py
@@ -3542,8 +3542,12 @@ def _parse_stdin_context(raw_stdin):
             # schema. Only override if stdin didn't already provide rate_limits.
             if not result.get("_rate_limits"):
                 try:
+                    # npm installs mmx as a .cmd shim on Windows, which
+                    # subprocess won't auto-resolve (only .exe) — resolve it
+                    # like _GIT_PATH/_CLAUDE_PATH above.
                     mmx_proc = subprocess.run(
-                        ["mmx", "quota", "show", "--output", "json", "--quiet"],
+                        [shutil.which("mmx") or "mmx",
+                         "quota", "show", "--output", "json", "--quiet"],
                         capture_output=True, text=True, timeout=3,
                     )
                     if mmx_proc.returncode == 0:


### PR DESCRIPTION
Hi! Tiny follow-up to the MiniMax provider (#43/#44), found while running it on a Windows host.

## The bug

On Windows, npm installs the `mmx` CLI as a `.cmd` shim, but `subprocess.run(["mmx", ...])` only auto-resolves `.exe` — the quota fetch raises `FileNotFoundError`, which the crash-proofing catch silently swallows. Net effect: MiniMax sessions on Windows fall back to the Anthropic OAuth bars even with `mmx` installed and authed, and nothing in the output hints why.

## The fix

One line — resolve the binary via `shutil.which("mmx") or "mmx"` before the call, the same pattern `claude_status.py` already uses for `_GIT_PATH` and `_CLAUDE_PATH`. `shutil.which` finds `.cmd`/`.bat` shims through `PATHEXT`, and the `or "mmx"` fallback keeps the previous behavior (clean `FileNotFoundError` → existing fallback) when mmx isn't installed at all.

## Behavior

- **Linux/macOS**: no change — `shutil.which` returns the same binary the bare name resolved to.
- **Windows, mmx installed**: quota fetch now works; MiniMax Session/Weekly bars render (verified live on Windows 11 / Python 3.13: bare call → `FileNotFoundError`, patched → real quota bars in a simulated `mxclaude` session; ordinary Anthropic sessions unaffected, exit 0).
- **Windows, mmx missing**: unchanged fallback, no crash.

---

*Drafted with AI assistance. Reviewed and submitted by a human.*